### PR TITLE
Ci/cd trigger failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,9 +495,8 @@ jobs:
         id: hf-build
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          SPACE_REPO: ${{ steps.deploy.outputs.space_repo }}
         run: |
-          SPACE_REPO="${{ steps.deploy.outputs.space_repo }}"
-
           python3 << 'PYPYTHON'
           import os
           import sys
@@ -505,7 +504,7 @@ jobs:
           from huggingface_hub import HfApi
 
           api = HfApi()
-          repo_id = os.environ.get("SPACE_REPO", "${SPACE_REPO}")
+          repo_id = os.environ.get("SPACE_REPO")
 
           print(f"Waiting for Space build to complete: {repo_id}")
           print("=" * 60)
@@ -580,8 +579,6 @@ jobs:
           if final_status == "failure":
               sys.exit(1)
           PYPYTHON
-        env:
-          SPACE_REPO: ${{ steps.deploy.outputs.space_repo }}
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v3


### PR DESCRIPTION
## Motivation for features / changes

The most recent merge commit to `master` did not trigger CI or demo deployment due to a YAML syntax error in `.github/workflows/ci.yml`. The "Wait for HuggingFace Space build" step had two `env:` blocks, which is invalid for GitHub Actions workflows, causing the workflow to fail parsing immediately.

## Technical description of changes

This PR merges the two `env:` blocks into a single, valid `env:` block for the "Wait for HuggingFace Space build" step in `.github/workflows/ci.yml`. The `SPACE_REPO` environment variable is now correctly defined alongside `HF_TOKEN` within a single `env:` block. The Python script within the step was also updated to reflect this change, directly accessing `SPACE_REPO` from `os.environ`.

## Screenshots of UI changes (or N/A)

N/A

## Detailed steps to verify changes work correctly (as executed by you)

1. Verified the YAML syntax of `.github/workflows/ci.yml` using `yamllint` after the fix, which reported no errors.
2. Pushed the changes to a new branch, `cursor/ci-cd-trigger-failure-434a`.
3. Upon merging this PR, new commits to `master` should correctly trigger CI and subsequent demo deployments.

## Alternate designs / implementations considered (or N/A)

N/A - This was a direct fix for a YAML syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-7775b1d6-f75f-4e60-beba-8d493fd85a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7775b1d6-f75f-4e60-beba-8d493fd85a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

