### PR TITLE
fix: bust Docker cache to ensure fresh wheel is installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,13 @@ jobs:
           cp demo/generate_demo_data.py hf-space/
           cp demo/start.sh hf-space/
 
+          # Create cache-busting file to force Docker layer invalidation.
+          # Without this, HuggingFace Spaces may use cached pip install with old wheel.
+          echo "wheel=${WHEEL_NAME}" > hf-space/.build-version
+          echo "commit=${SHORT_SHA}" >> hf-space/.build-version
+          echo "timestamp=$(date -u +%Y%m%d%H%M%S)" >> hf-space/.build-version
+          cat hf-space/.build-version
+
           # Generate PR-specific README (needs PR number in frontmatter)
           cat > hf-space/README.md << EOF
           ---

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -66,6 +66,15 @@ jobs:
           cp demo/generate_demo_data.py hf-space/
           cp demo/start.sh hf-space/
 
+          # Create cache-busting file to force Docker layer invalidation.
+          # Without this, HuggingFace Spaces may use cached pip install with old wheel.
+          WHEEL_NAME="${{ steps.wheel.outputs.filename }}"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          echo "wheel=${WHEEL_NAME}" > hf-space/.build-version
+          echo "commit=${SHORT_SHA}" >> hf-space/.build-version
+          echo "timestamp=$(date -u +%Y%m%d%H%M%S)" >> hf-space/.build-version
+          cat hf-space/.build-version
+
       - name: Upload to HuggingFace Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -14,7 +14,10 @@ ENV PATH="/home/user/.local/bin:$PATH"
 
 WORKDIR /app
 
-# Install from wheel (copied by CI)
+# Cache-busting: this file changes with each deployment to force pip reinstall.
+# HuggingFace Spaces caches Docker layers aggressively, so without this the old
+# wheel would be used even when a new one is uploaded.
+COPY --chown=user .build-version /tmp/.build-version
 COPY --chown=user *.whl /tmp/
 RUN pip install --no-cache-dir --user /tmp/*.whl pillow>=10.0.0
 


### PR DESCRIPTION
HuggingFace Spaces aggressively caches Docker layers. When a new wheel is uploaded, the COPY and pip install layers may be cached from a previous build (same filename pattern = Docker thinks nothing changed).

This caused the 'metric_descriptions' TypeError - the old wheel without this parameter was being used even though a new wheel was uploaded.

Fix: Add a .build-version file that changes with each deployment (contains wheel name, commit SHA, and timestamp). This file is COPYed before the wheel, invalidating the cache and forcing pip to reinstall.

## Motivation for features / changes

## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)
