### PR TITLE
Broken auto deployment

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   id-token: write # Needed for PyPI OIDC trusted publishing
+  pull-requests: write # Needed by ci.yml for PR preview comments
 
 jobs:
   ci:
@@ -23,7 +24,7 @@ jobs:
       - name: Download pip package
         uses: actions/download-artifact@v4
         with:
-          pattern: tensorbored-nightly_py*
+          pattern: tensorbored-wheel_py*
           # Download all matching artifacts in the same directory (specified by path)
           merge-multiple: true
           path: wheels

--- a/.github/workflows/wheel-prerelease.yml
+++ b/.github/workflows/wheel-prerelease.yml
@@ -15,6 +15,8 @@ on:
 permissions:
   contents: write # Needed for creating releases
   id-token: write # Needed for PyPI OIDC trusted publishing
+  pull-requests: write # Needed by ci.yml for PR preview comments
+  actions: read # Needed by deploy-demo.yml for artifact downloads
 
 env:
   BAZEL_VERSION: '6.5.0'


### PR DESCRIPTION
## Motivation for features / changes

The auto-deployment to `demonstrandum-tensorbored-sample.hf.space` was broken due to `startup_failure` in the `Wheel Prerelease` and `nightly-release` workflows. This was caused by permission mismatches when calling reusable workflows (`ci.yml` and `deploy-demo.yml`), as the callers did not grant all permissions requested by the called workflows. Additionally, `nightly-release.yml` was attempting to download an artifact with an incorrect name.

## Technical description of changes

-   **`.github/workflows/wheel-prerelease.yml`**:
    -   Added `pull-requests: write` permission, required by `ci.yml` for PR preview comments.
    -   Added `actions: read` permission, required by `deploy-demo.yml` for artifact downloads.
-   **`.github/workflows/nightly-release.yml`**:
    -   Added `pull-requests: write` permission, required by `ci.yml` for PR preview comments.
    -   Updated the artifact download pattern from `tensorbored-nightly_py*` to `tensorbored-wheel_py*` to match the artifact name uploaded by `ci.yml`.

## Screenshots of UI changes (or N/A)

N/A

## Detailed steps to verify changes work correctly (as executed by you)

1.  Identified `startup_failure` in workflow runs by inspecting GitHub Actions logs.
2.  Compared workflow file changes between successful and failing commits to pinpoint permission additions in `ci.yml` and `deploy-demo.yml`.
3.  Verified the permission contract violation: `wheel-prerelease.yml` and `nightly-release.yml` were not granting `pull-requests: write` (for `ci.yml`) and `actions: read` (for `deploy-demo.yml`).
4.  Identified the artifact name mismatch in `nightly-release.yml`.
5.  Applied the changes to add the necessary permissions and correct the artifact name.
6.  Ran `actionlint` on the modified workflow files (`wheel-prerelease.yml` and `nightly-release.yml`) to ensure YAML validity and caught no issues.
7.  The ultimate verification will be to merge this PR and observe successful runs of the `Wheel Prerelease` and `nightly-release` workflows.

## Alternate designs / implementations considered (or N/A)

N/A

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d1a453e8-35f2-4db9-954f-d748f5fcfbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1a453e8-35f2-4db9-954f-d748f5fcfbed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to GitHub Actions workflow permissions and artifact naming; main risk is unintended permission broadening, but scopes are narrowly targeted.
> 
> **Overview**
> Fixes broken automated deployments by updating GitHub Actions workflow permission grants when calling reusable workflows.
> 
> `wheel-prerelease.yml` and `nightly-release.yml` now include `pull-requests: write` (to allow `ci.yml` to post PR preview comments), and `wheel-prerelease.yml` also adds `actions: read` (to allow `deploy-demo.yml` artifact downloads). `nightly-release.yml` also updates its artifact download pattern to match the wheel artifact name produced by CI (`tensorbored-wheel_py*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f65256fc57222309f0154ff81d4eadd8b774202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->