### PR TITLE
fix(deploy): fix wheel download condition in deploy-demo.yml

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download wheel artifact (workflow_call)
-        if: github.event_name == 'workflow_call'
+      - name: Download wheel artifact (from parent workflow run)
+        # When called via workflow_call, github.event_name inherits the
+        # caller's event (e.g. 'push'), NOT 'workflow_call'. So we match
+        # on "anything that isn't workflow_dispatch".
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@v4
         with:
           name: tensorbored-rc-wheel


### PR DESCRIPTION
When deploy-demo.yml is called via workflow_call from wheel-prerelease.yml, github.event_name inherits the caller's event name ('push'), NOT 'workflow_call'. The condition
'github.event_name == workflow_call' was always false, so the wheel artifact was never downloaded, causing 'cp: cannot stat wheel/*.whl'.

Fix: change the condition to 'github.event_name != workflow_dispatch' which correctly matches both the workflow_call case (where event_name is 'push') and any other non-dispatch trigger.

## Motivation for features / changes

## Technical description of changes

## Screenshots of UI changes (or N/A)

## Detailed steps to verify changes work correctly (as executed by you)

## Alternate designs / implementations considered (or N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions condition change; low risk aside from potentially changing when artifacts are downloaded during CI runs.
> 
> **Overview**
> Fixes the `deploy-demo.yml` wheel download step so it runs when the workflow is invoked via `workflow_call` (where `github.event_name` reflects the caller event like `push`), by switching the condition from `github.event_name == 'workflow_call'` to `github.event_name != 'workflow_dispatch'`.
> 
> Adds clarifying comments and keeps the `workflow_dispatch` paths (with/without `run_id`) unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eac3f381ccae23fd69896127c0c3835e6219e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->