### PR TITLE
feat: replace hard-to-grab resize tabs with card edge/corner resizing

### DIFF
--- a/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -192,10 +192,7 @@ limitations under the License.
       </mat-menu>
     </span>
   </div>
-  <div
-    #chartContainer
-    class="chart-container"
-  >
+  <div #chartContainer class="chart-container">
     <mat-spinner
       diameter="18"
       *ngIf="loadState === DataLoadState.LOADING"

--- a/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
+++ b/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.ng.html
@@ -195,7 +195,6 @@ limitations under the License.
   <div
     #chartContainer
     class="chart-container"
-    [persistResize]="'scalar-chart:' + tag"
   >
     <mat-spinner
       diameter="18"

--- a/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.scss
+++ b/tensorbored/webapp/metrics/views/card_renderer/scalar_card_component.scss
@@ -95,7 +95,6 @@ $_data_table_initial_height: 100px;
   flex-direction: column;
   flex-grow: 1;
   overflow: hidden;
-  resize: vertical;
 
   mat-spinner {
     $mat-icon-button-diameter: 40px;

--- a/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.ng.html
+++ b/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.ng.html
@@ -111,9 +111,7 @@ limitations under the License.
     </div>
   </div>
 
-  <div
-    class="chart-container"
-  >
+  <div class="chart-container">
     <mat-spinner
       diameter="18"
       *ngIf="loadState === DataLoadState.LOADING"

--- a/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.ng.html
+++ b/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.ng.html
@@ -113,7 +113,6 @@ limitations under the License.
 
   <div
     class="chart-container"
-    [persistResize]="'superimposed-chart:' + superimposedCardId"
   >
     <mat-spinner
       diameter="18"

--- a/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.scss
+++ b/tensorbored/webapp/metrics/views/card_renderer/superimposed_card_component.scss
@@ -123,7 +123,6 @@ limitations under the License.
   overflow: hidden;
   position: relative;
   padding: 8px;
-  resize: vertical;
 
   mat-spinner {
     position: absolute;

--- a/tensorbored/webapp/metrics/views/main_view/BUILD
+++ b/tensorbored/webapp/metrics/views/main_view/BUILD
@@ -166,6 +166,7 @@ tf_ng_module(
         "//tensorbored/webapp/types:ui",
         "//tensorbored/webapp/util:string",
         "//tensorbored/webapp/util:types",
+        "//tensorbored/webapp/widgets:edge_resize",
         "//tensorbored/webapp/widgets/filter_input",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorbored/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorbored/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -39,7 +39,7 @@ limitations under the License.
           'full-height': cardsAtFullHeight.has(item.cardId) || cardStateMap[item.cardId]?.tableExpanded
         }"
       [cardEdgeResize]="'card:' + item.cardId"
-      (fullWidthRequested)="onFullWidthChanged(item.cardId, $event)"
+      (columnSpanChanged)="onColumnSpanChanged(item.cardId, $event)"
       cdkDrag
       [cdkDragDisabled]="!allowPinnedReorder"
       [cdkDragStartDelay]="dragStartDelayMs"

--- a/tensorbored/webapp/metrics/views/main_view/card_grid_component.ng.html
+++ b/tensorbored/webapp/metrics/views/main_view/card_grid_component.ng.html
@@ -38,6 +38,8 @@ limitations under the License.
           'full-width': cardsAtFullWidth.has(item.cardId) || cardStateMap[item.cardId]?.fullWidth,
           'full-height': cardsAtFullHeight.has(item.cardId) || cardStateMap[item.cardId]?.tableExpanded
         }"
+      [cardEdgeResize]="'card:' + item.cardId"
+      (fullWidthRequested)="onFullWidthChanged(item.cardId, $event)"
       cdkDrag
       [cdkDragDisabled]="!allowPinnedReorder"
       [cdkDragStartDelay]="dragStartDelayMs"

--- a/tensorbored/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/card_grid_component.scss
@@ -34,6 +34,56 @@ $_background: map-get($tb-theme, background);
 .card-space {
   display: flex;
   flex-direction: column;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 8px;
+    height: 8px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  &:hover::after {
+    opacity: 0.3;
+  }
+
+  &[data-resize-edge='bottom']::after,
+  &[data-resize-edge='right']::after,
+  &[data-resize-edge='corner']::after {
+    opacity: 0.8;
+  }
+
+  &[data-resize-edge='bottom']::after {
+    width: 100%;
+    height: 3px;
+    right: 0;
+    bottom: 0;
+    background: currentColor;
+    border-radius: 2px;
+  }
+
+  &[data-resize-edge='right']::after {
+    width: 3px;
+    height: 100%;
+    right: 0;
+    bottom: 0;
+    background: currentColor;
+    border-radius: 2px;
+  }
+
+  &[data-resize-edge='corner']::after {
+    width: 12px;
+    height: 12px;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, transparent 50%, currentColor 50%);
+    border-radius: 0 0 4px 0;
+  }
 }
 
 .card-space.full-width {

--- a/tensorbored/webapp/metrics/views/main_view/card_grid_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/card_grid_component.scss
@@ -91,6 +91,15 @@ $_background: map-get($tb-theme, background);
   grid-column-end: -1;
 }
 
+.card-space.edge-resizing-width {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  transition: none;
+
+  @include tb-dark-theme {
+    box-shadow: 0 2px 12px rgba(255, 255, 255, 0.1);
+  }
+}
+
 .card-space.full-height {
   min-height: $metrics-min-card-height * 1.5;
 

--- a/tensorbored/webapp/metrics/views/main_view/card_grid_component.ts
+++ b/tensorbored/webapp/metrics/views/main_view/card_grid_component.ts
@@ -232,4 +232,8 @@ export class CardGridComponent {
       this.cardsAtFullHeight.delete(cardId);
     }
   }
+
+  onColumnSpanChanged(cardId: CardId, _span: number) {
+    this.cardsAtFullWidth.delete(cardId);
+  }
 }

--- a/tensorbored/webapp/metrics/views/main_view/main_view_module.ts
+++ b/tensorbored/webapp/metrics/views/main_view/main_view_module.ts
@@ -25,6 +25,7 @@ import {MatInputModule} from '@angular/material/input';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {FilterInputModule} from '../../../widgets/filter_input/filter_input_module';
 import {CardRendererModule} from '../card_renderer/card_renderer_module';
+import {EdgeResizeModule} from '../../../widgets/edge_resize_module';
 import {RightPaneModule} from '../right_pane/right_pane_module';
 import {ScalarColumnEditorModule} from '../right_pane/scalar_column_editor/scalar_column_editor_module';
 import {CardGridComponent} from './card_grid_component';
@@ -73,6 +74,7 @@ import {SuperimposedCardsViewContainer} from './superimposed_cards_view_containe
     CommonModule,
     CustomizationModule,
     DragDropModule,
+    EdgeResizeModule,
     FilterInputModule,
     MatAutocompleteModule,
     MatButtonModule,

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
@@ -95,6 +95,11 @@ limitations under the License.
       min-height: $metrics-min-card-height * 1.5;
     }
 
+    &.edge-resizing-width {
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+      transition: none;
+    }
+
     &::after {
       content: '';
       position: absolute;

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
@@ -84,6 +84,7 @@ limitations under the License.
     border-radius: 4px;
     box-sizing: border-box;
     min-height: $metrics-min-card-height;
+    position: relative;
 
     &.full-width {
       grid-column-start: 1;
@@ -92,6 +93,49 @@ limitations under the License.
 
     &.full-height {
       min-height: $metrics-min-card-height * 1.5;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 8px;
+      height: 8px;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s;
+    }
+
+    &:hover::after {
+      opacity: 0.3;
+    }
+
+    &[data-resize-edge='bottom']::after,
+    &[data-resize-edge='right']::after,
+    &[data-resize-edge='corner']::after {
+      opacity: 0.8;
+    }
+
+    &[data-resize-edge='bottom']::after {
+      width: 100%;
+      height: 3px;
+      background: currentColor;
+      border-radius: 2px;
+    }
+
+    &[data-resize-edge='right']::after {
+      width: 3px;
+      height: 100%;
+      background: currentColor;
+      border-radius: 2px;
+    }
+
+    &[data-resize-edge='corner']::after {
+      width: 12px;
+      height: 12px;
+      background: linear-gradient(135deg, transparent 50%, currentColor 50%);
+      border-radius: 0 0 4px 0;
     }
   }
 }

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
@@ -58,7 +58,7 @@ const MAX_CARD_MIN_WIDTH_IN_PX = 735;
           [class.full-width]="(cardsAtFullWidth$ | async)?.has(card.id)"
           [class.full-height]="cardsAtFullHeight.has(card.id)"
           [cardEdgeResize]="'superimposed:' + card.id"
-          (fullWidthRequested)="onFullWidthChanged(card.id, $event)"
+          (columnSpanChanged)="onColumnSpanChanged(card.id, $event)"
         >
           <superimposed-card
             [superimposedCardId]="card.id"
@@ -120,5 +120,10 @@ export class SuperimposedCardsViewComponent implements OnChanges {
     } else {
       this.cardsAtFullHeight.delete(cardId);
     }
+  }
+
+  onColumnSpanChanged(_cardId: string, _span: number) {
+    // Width is handled directly by the directive's inline grid-column style.
+    // No store dispatch needed — the span is persisted in localStorage by the directive.
   }
 }

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
@@ -57,6 +57,8 @@ const MAX_CARD_MIN_WIDTH_IN_PX = 735;
           class="card-wrapper"
           [class.full-width]="(cardsAtFullWidth$ | async)?.has(card.id)"
           [class.full-height]="cardsAtFullHeight.has(card.id)"
+          [cardEdgeResize]="'superimposed:' + card.id"
+          (fullWidthRequested)="onFullWidthChanged(card.id, $event)"
         >
           <superimposed-card
             [superimposedCardId]="card.id"

--- a/tensorbored/webapp/widgets/BUILD
+++ b/tensorbored/webapp/widgets/BUILD
@@ -18,6 +18,17 @@ tf_ng_module(
 )
 
 tf_ng_module(
+    name = "edge_resize",
+    srcs = [
+        "edge_resize_directive.ts",
+        "edge_resize_module.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ng_module(
     name = "resize_detector",
     srcs = [
         "resize_detector_directive.ts",

--- a/tensorbored/webapp/widgets/edge_resize_directive.ts
+++ b/tensorbored/webapp/widgets/edge_resize_directive.ts
@@ -32,6 +32,7 @@ const enum ResizeEdge {
 
 const EDGE_ZONE_PX = 8;
 const MIN_HEIGHT_PX = 200;
+const MIN_WIDTH_PX = 200;
 const STORAGE_KEY = '_tb_card_sizes.v1';
 
 interface CardSize {
@@ -87,14 +88,11 @@ function getGridGap(gridEl: HTMLElement): number {
 /**
  * Adds edge and corner resize handles to a card element in a CSS grid.
  *
- * Bottom edge: drag to resize height.
- * Right edge:  drag to span more or fewer grid columns.
+ * Bottom edge: drag to resize height (smooth, pixel-based).
+ * Right edge:  drag to resize width (smooth pixel-based during drag,
+ *              snaps to grid column span on release).
  * Corner:      both.
  * Double-click bottom edge resets height; right edge resets column span.
- *
- * Usage:
- *   <div [cardEdgeResize]="uniqueKey"
- *        (columnSpanChanged)="onSpanChanged(cardId, $event)">
  */
 @Directive({
   standalone: false,
@@ -106,10 +104,11 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
 
   private readonly el: HTMLElement;
   private activeEdge = ResizeEdge.NONE;
+  private startX = 0;
   private startY = 0;
   private startHeight = 0;
+  private startWidth = 0;
   private startColSpan = 1;
-  private startRight = 0;
   private gridColWidth = 0;
   private gridGap = 0;
   private gridTotalCols = 1;
@@ -219,6 +218,13 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     return Math.max(1, Math.min(this.gridTotalCols, Math.round(raw)));
   }
 
+  private getMaxWidth(): number {
+    return (
+      this.gridTotalCols * this.gridColWidth +
+      (this.gridTotalCols - 1) * this.gridGap
+    );
+  }
+
   private handleHover(e: MouseEvent) {
     if (this.dragging) return;
     const edge = this.edgeAt(e);
@@ -237,13 +243,26 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     if (edge === ResizeEdge.NONE) return;
     e.preventDefault();
     e.stopPropagation();
+
     this.dragging = true;
     this.activeEdge = edge;
+    this.startX = e.clientX;
     this.startY = e.clientY;
-    this.startHeight = this.el.getBoundingClientRect().height;
-    this.startRight = this.el.getBoundingClientRect().right;
+    const rect = this.el.getBoundingClientRect();
+    this.startHeight = rect.height;
+    this.startWidth = rect.width;
     this.startColSpan = this.getCurrentColSpan();
     this.snapshotGrid();
+
+    if (edge & ResizeEdge.RIGHT) {
+      this.el.style.width = `${this.startWidth}px`;
+      this.el.style.gridColumn = '';
+      this.el.style.zIndex = '10';
+      this.el.style.position = 'relative';
+      this.el.style.overflow = 'hidden';
+      this.el.classList.add('edge-resizing-width');
+    }
+
     document.body.style.cursor = this.cursorFor(edge);
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', this.onDocMove);
@@ -260,13 +279,12 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
       this.el.style.height = `${h}px`;
     }
     if (this.activeEdge & ResizeEdge.RIGHT) {
-      const dx = e.clientX - this.startRight;
-      const startWidth =
-        this.startColSpan * this.gridColWidth +
-        (this.startColSpan - 1) * this.gridGap;
-      const desiredWidth = startWidth + dx;
-      const span = this.spanForWidth(desiredWidth);
-      this.applyColSpan(span);
+      const dx = e.clientX - this.startX;
+      const w = Math.max(
+        MIN_WIDTH_PX,
+        Math.min(this.startWidth + dx, this.getMaxWidth())
+      );
+      this.el.style.width = `${w}px`;
     }
   }
 
@@ -290,13 +308,16 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     }
 
     if (this.activeEdge & ResizeEdge.RIGHT) {
-      const dx = e.clientX - this.startRight;
-      const startWidth =
-        this.startColSpan * this.gridColWidth +
-        (this.startColSpan - 1) * this.gridGap;
-      const desiredWidth = startWidth + dx;
-      const span = this.spanForWidth(desiredWidth);
+      const currentWidth = this.el.getBoundingClientRect().width;
+      const span = this.spanForWidth(currentWidth);
+
+      this.el.style.width = '';
+      this.el.style.zIndex = '';
+      this.el.style.position = '';
+      this.el.style.overflow = '';
+      this.el.classList.remove('edge-resizing-width');
       this.applyColSpan(span);
+
       if (this.persistKey) persistSize(this.persistKey, {colSpan: span});
       this.zone.run(() => this.columnSpanChanged.emit(span));
     }
@@ -312,6 +333,7 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
       if (this.persistKey) clearSize(this.persistKey, 'height');
     }
     if (edge & ResizeEdge.RIGHT) {
+      this.snapshotGrid();
       this.applyColSpan(1);
       if (this.persistKey) clearSize(this.persistKey, 'colSpan');
       this.zone.run(() => this.columnSpanChanged.emit(1));

--- a/tensorbored/webapp/widgets/edge_resize_directive.ts
+++ b/tensorbored/webapp/widgets/edge_resize_directive.ts
@@ -27,45 +27,74 @@ const enum ResizeEdge {
   NONE = 0,
   RIGHT = 1,
   BOTTOM = 2,
-  CORNER = 3, // RIGHT | BOTTOM
+  CORNER = 3,
 }
 
 const EDGE_ZONE_PX = 8;
 const MIN_HEIGHT_PX = 200;
-const FULL_WIDTH_DRAG_THRESHOLD_PX = 50;
 const STORAGE_KEY = '_tb_card_sizes.v1';
 
-function loadSizes(): Record<string, number> {
+interface CardSize {
+  height?: number;
+  colSpan?: number;
+}
+
+function loadSizes(): Record<string, CardSize> {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    return raw ? (JSON.parse(raw) as Record<string, CardSize>) : {};
   } catch {
     return {};
   }
 }
 
-function persistHeight(key: string, height: number) {
+function persistSize(key: string, size: CardSize) {
   const sizes = loadSizes();
-  sizes[key] = Math.round(height);
+  const existing = sizes[key] ?? {};
+  if (size.height !== undefined) existing.height = Math.round(size.height);
+  if (size.colSpan !== undefined) existing.colSpan = size.colSpan;
+  sizes[key] = existing;
   localStorage.setItem(STORAGE_KEY, JSON.stringify(sizes));
 }
 
-function removeHeight(key: string) {
+function clearSize(key: string, field: 'height' | 'colSpan') {
   const sizes = loadSizes();
-  delete sizes[key];
+  const existing = sizes[key];
+  if (!existing) return;
+  delete existing[field];
+  if (!existing.height && !existing.colSpan) {
+    delete sizes[key];
+  }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(sizes));
+}
+
+function getGridColumnCount(gridEl: HTMLElement): number {
+  const cols = getComputedStyle(gridEl).gridTemplateColumns;
+  return cols.split(' ').filter((s) => s.length > 0).length;
+}
+
+function getGridColumnWidth(gridEl: HTMLElement): number {
+  const cols = getComputedStyle(gridEl).gridTemplateColumns;
+  const parts = cols.split(' ').filter((s) => s.length > 0);
+  if (parts.length === 0) return 0;
+  return parseFloat(parts[0]);
+}
+
+function getGridGap(gridEl: HTMLElement): number {
+  return parseFloat(getComputedStyle(gridEl).columnGap) || 0;
 }
 
 /**
- * Adds edge and corner resize handles to a card wrapper element.
+ * Adds edge and corner resize handles to a card element in a CSS grid.
  *
- * Bottom edge:  drag to resize height.
- * Right edge:   drag > threshold emits fullWidthRequested.
- * Corner:       both.
- * Double-click on bottom edge resets height; on right edge toggles full-width.
+ * Bottom edge: drag to resize height.
+ * Right edge:  drag to span more or fewer grid columns.
+ * Corner:      both.
+ * Double-click bottom edge resets height; right edge resets column span.
  *
- * Usage:  <div [cardEdgeResize]="uniqueKey"
- *              (fullWidthRequested)="onFullWidth($event)">
+ * Usage:
+ *   <div [cardEdgeResize]="uniqueKey"
+ *        (columnSpanChanged)="onSpanChanged(cardId, $event)">
  */
 @Directive({
   standalone: false,
@@ -73,13 +102,17 @@ function removeHeight(key: string) {
 })
 export class CardEdgeResizeDirective implements OnInit, OnDestroy {
   @Input('cardEdgeResize') persistKey = '';
-  @Output() fullWidthRequested = new EventEmitter<boolean>();
+  @Output() columnSpanChanged = new EventEmitter<number>();
 
   private readonly el: HTMLElement;
   private activeEdge = ResizeEdge.NONE;
-  private startX = 0;
   private startY = 0;
   private startHeight = 0;
+  private startColSpan = 1;
+  private startRight = 0;
+  private gridColWidth = 0;
+  private gridGap = 0;
+  private gridTotalCols = 1;
   private dragging = false;
 
   private readonly onHover: (e: MouseEvent) => void;
@@ -89,10 +122,7 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
   private readonly onLeave: () => void;
   private readonly onDblClick: (e: MouseEvent) => void;
 
-  constructor(
-    ref: ElementRef<HTMLElement>,
-    private readonly zone: NgZone
-  ) {
+  constructor(ref: ElementRef<HTMLElement>, private readonly zone: NgZone) {
     this.el = ref.nativeElement;
     this.onHover = this.handleHover.bind(this);
     this.onDown = this.handleDown.bind(this);
@@ -105,8 +135,11 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
   ngOnInit() {
     if (this.persistKey) {
       const saved = loadSizes()[this.persistKey];
-      if (saved) {
-        this.el.style.height = `${saved}px`;
+      if (saved?.height) {
+        this.el.style.height = `${saved.height}px`;
+      }
+      if (saved?.colSpan && saved.colSpan > 1) {
+        this.el.style.gridColumn = `span ${saved.colSpan}`;
       }
     }
     this.zone.runOutsideAngular(() => {
@@ -128,10 +161,8 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
 
   private edgeAt(e: MouseEvent): ResizeEdge {
     const r = this.el.getBoundingClientRect();
-    const nearR =
-      r.right - e.clientX <= EDGE_ZONE_PX && e.clientX >= r.left;
-    const nearB =
-      r.bottom - e.clientY <= EDGE_ZONE_PX && e.clientY >= r.top;
+    const nearR = r.right - e.clientX <= EDGE_ZONE_PX && e.clientX >= r.left;
+    const nearB = r.bottom - e.clientY <= EDGE_ZONE_PX && e.clientY >= r.top;
     if (nearR && nearB) return ResizeEdge.CORNER;
     if (nearB) return ResizeEdge.BOTTOM;
     if (nearR) return ResizeEdge.RIGHT;
@@ -150,6 +181,42 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     if (edge === ResizeEdge.BOTTOM) return 'bottom';
     if (edge === ResizeEdge.RIGHT) return 'right';
     return '';
+  }
+
+  private applyColSpan(span: number) {
+    if (span >= this.gridTotalCols) {
+      this.el.style.gridColumn = '1 / -1';
+    } else if (span <= 1) {
+      this.el.style.gridColumn = '';
+    } else {
+      this.el.style.gridColumn = `span ${span}`;
+    }
+  }
+
+  private getCurrentColSpan(): number {
+    const gc = this.el.style.gridColumn;
+    if (!gc) return 1;
+    if (gc.includes('-1')) {
+      const grid = this.el.parentElement;
+      return grid ? getGridColumnCount(grid) : 1;
+    }
+    const m = gc.match(/span\s+(\d+)/);
+    return m ? parseInt(m[1], 10) : 1;
+  }
+
+  private snapshotGrid() {
+    const grid = this.el.parentElement;
+    if (!grid) return;
+    this.gridTotalCols = getGridColumnCount(grid);
+    this.gridColWidth = getGridColumnWidth(grid);
+    this.gridGap = getGridGap(grid);
+  }
+
+  private spanForWidth(desiredWidth: number): number {
+    if (this.gridColWidth <= 0) return 1;
+    const cellPlusGap = this.gridColWidth + this.gridGap;
+    const raw = (desiredWidth + this.gridGap) / cellPlusGap;
+    return Math.max(1, Math.min(this.gridTotalCols, Math.round(raw)));
   }
 
   private handleHover(e: MouseEvent) {
@@ -172,9 +239,11 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     e.stopPropagation();
     this.dragging = true;
     this.activeEdge = edge;
-    this.startX = e.clientX;
     this.startY = e.clientY;
     this.startHeight = this.el.getBoundingClientRect().height;
+    this.startRight = this.el.getBoundingClientRect().right;
+    this.startColSpan = this.getCurrentColSpan();
+    this.snapshotGrid();
     document.body.style.cursor = this.cursorFor(edge);
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', this.onDocMove);
@@ -189,6 +258,15 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
         this.startHeight + e.clientY - this.startY
       );
       this.el.style.height = `${h}px`;
+    }
+    if (this.activeEdge & ResizeEdge.RIGHT) {
+      const dx = e.clientX - this.startRight;
+      const startWidth =
+        this.startColSpan * this.gridColWidth +
+        (this.startColSpan - 1) * this.gridGap;
+      const desiredWidth = startWidth + dx;
+      const span = this.spanForWidth(desiredWidth);
+      this.applyColSpan(span);
     }
   }
 
@@ -208,16 +286,19 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
         this.startHeight + e.clientY - this.startY
       );
       this.el.style.height = `${h}px`;
-      if (this.persistKey) persistHeight(this.persistKey, h);
+      if (this.persistKey) persistSize(this.persistKey, {height: h});
     }
 
     if (this.activeEdge & ResizeEdge.RIGHT) {
-      const dx = e.clientX - this.startX;
-      if (dx > FULL_WIDTH_DRAG_THRESHOLD_PX) {
-        this.zone.run(() => this.fullWidthRequested.emit(true));
-      } else if (dx < -FULL_WIDTH_DRAG_THRESHOLD_PX) {
-        this.zone.run(() => this.fullWidthRequested.emit(false));
-      }
+      const dx = e.clientX - this.startRight;
+      const startWidth =
+        this.startColSpan * this.gridColWidth +
+        (this.startColSpan - 1) * this.gridGap;
+      const desiredWidth = startWidth + dx;
+      const span = this.spanForWidth(desiredWidth);
+      this.applyColSpan(span);
+      if (this.persistKey) persistSize(this.persistKey, {colSpan: span});
+      this.zone.run(() => this.columnSpanChanged.emit(span));
     }
 
     this.activeEdge = ResizeEdge.NONE;
@@ -228,14 +309,12 @@ export class CardEdgeResizeDirective implements OnInit, OnDestroy {
     if (edge === ResizeEdge.NONE) return;
     if (edge & ResizeEdge.BOTTOM) {
       this.el.style.height = '';
-      if (this.persistKey) removeHeight(this.persistKey);
+      if (this.persistKey) clearSize(this.persistKey, 'height');
     }
     if (edge & ResizeEdge.RIGHT) {
-      this.zone.run(() =>
-        this.fullWidthRequested.emit(
-          !this.el.classList.contains('full-width')
-        )
-      );
+      this.applyColSpan(1);
+      if (this.persistKey) clearSize(this.persistKey, 'colSpan');
+      this.zone.run(() => this.columnSpanChanged.emit(1));
     }
   }
 }

--- a/tensorbored/webapp/widgets/edge_resize_directive.ts
+++ b/tensorbored/webapp/widgets/edge_resize_directive.ts
@@ -1,0 +1,241 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+
+const enum ResizeEdge {
+  NONE = 0,
+  RIGHT = 1,
+  BOTTOM = 2,
+  CORNER = 3, // RIGHT | BOTTOM
+}
+
+const EDGE_ZONE_PX = 8;
+const MIN_HEIGHT_PX = 200;
+const FULL_WIDTH_DRAG_THRESHOLD_PX = 50;
+const STORAGE_KEY = '_tb_card_sizes.v1';
+
+function loadSizes(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistHeight(key: string, height: number) {
+  const sizes = loadSizes();
+  sizes[key] = Math.round(height);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sizes));
+}
+
+function removeHeight(key: string) {
+  const sizes = loadSizes();
+  delete sizes[key];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sizes));
+}
+
+/**
+ * Adds edge and corner resize handles to a card wrapper element.
+ *
+ * Bottom edge:  drag to resize height.
+ * Right edge:   drag > threshold emits fullWidthRequested.
+ * Corner:       both.
+ * Double-click on bottom edge resets height; on right edge toggles full-width.
+ *
+ * Usage:  <div [cardEdgeResize]="uniqueKey"
+ *              (fullWidthRequested)="onFullWidth($event)">
+ */
+@Directive({
+  standalone: false,
+  selector: '[cardEdgeResize]',
+})
+export class CardEdgeResizeDirective implements OnInit, OnDestroy {
+  @Input('cardEdgeResize') persistKey = '';
+  @Output() fullWidthRequested = new EventEmitter<boolean>();
+
+  private readonly el: HTMLElement;
+  private activeEdge = ResizeEdge.NONE;
+  private startX = 0;
+  private startY = 0;
+  private startHeight = 0;
+  private dragging = false;
+
+  private readonly onHover: (e: MouseEvent) => void;
+  private readonly onDown: (e: MouseEvent) => void;
+  private readonly onDocMove: (e: MouseEvent) => void;
+  private readonly onDocUp: (e: MouseEvent) => void;
+  private readonly onLeave: () => void;
+  private readonly onDblClick: (e: MouseEvent) => void;
+
+  constructor(
+    ref: ElementRef<HTMLElement>,
+    private readonly zone: NgZone
+  ) {
+    this.el = ref.nativeElement;
+    this.onHover = this.handleHover.bind(this);
+    this.onDown = this.handleDown.bind(this);
+    this.onDocMove = this.handleDocMove.bind(this);
+    this.onDocUp = this.handleDocUp.bind(this);
+    this.onLeave = this.handleLeave.bind(this);
+    this.onDblClick = this.handleDblClick.bind(this);
+  }
+
+  ngOnInit() {
+    if (this.persistKey) {
+      const saved = loadSizes()[this.persistKey];
+      if (saved) {
+        this.el.style.height = `${saved}px`;
+      }
+    }
+    this.zone.runOutsideAngular(() => {
+      this.el.addEventListener('mousemove', this.onHover);
+      this.el.addEventListener('mousedown', this.onDown);
+      this.el.addEventListener('mouseleave', this.onLeave);
+      this.el.addEventListener('dblclick', this.onDblClick);
+    });
+  }
+
+  ngOnDestroy() {
+    this.el.removeEventListener('mousemove', this.onHover);
+    this.el.removeEventListener('mousedown', this.onDown);
+    this.el.removeEventListener('mouseleave', this.onLeave);
+    this.el.removeEventListener('dblclick', this.onDblClick);
+    document.removeEventListener('mousemove', this.onDocMove);
+    document.removeEventListener('mouseup', this.onDocUp);
+  }
+
+  private edgeAt(e: MouseEvent): ResizeEdge {
+    const r = this.el.getBoundingClientRect();
+    const nearR =
+      r.right - e.clientX <= EDGE_ZONE_PX && e.clientX >= r.left;
+    const nearB =
+      r.bottom - e.clientY <= EDGE_ZONE_PX && e.clientY >= r.top;
+    if (nearR && nearB) return ResizeEdge.CORNER;
+    if (nearB) return ResizeEdge.BOTTOM;
+    if (nearR) return ResizeEdge.RIGHT;
+    return ResizeEdge.NONE;
+  }
+
+  private cursorFor(edge: ResizeEdge): string {
+    if (edge === ResizeEdge.CORNER) return 'nwse-resize';
+    if (edge === ResizeEdge.BOTTOM) return 'ns-resize';
+    if (edge === ResizeEdge.RIGHT) return 'ew-resize';
+    return '';
+  }
+
+  private edgeName(edge: ResizeEdge): string {
+    if (edge === ResizeEdge.CORNER) return 'corner';
+    if (edge === ResizeEdge.BOTTOM) return 'bottom';
+    if (edge === ResizeEdge.RIGHT) return 'right';
+    return '';
+  }
+
+  private handleHover(e: MouseEvent) {
+    if (this.dragging) return;
+    const edge = this.edgeAt(e);
+    this.el.style.cursor = this.cursorFor(edge);
+    this.el.setAttribute('data-resize-edge', this.edgeName(edge));
+  }
+
+  private handleLeave() {
+    if (this.dragging) return;
+    this.el.style.cursor = '';
+    this.el.setAttribute('data-resize-edge', '');
+  }
+
+  private handleDown(e: MouseEvent) {
+    const edge = this.edgeAt(e);
+    if (edge === ResizeEdge.NONE) return;
+    e.preventDefault();
+    e.stopPropagation();
+    this.dragging = true;
+    this.activeEdge = edge;
+    this.startX = e.clientX;
+    this.startY = e.clientY;
+    this.startHeight = this.el.getBoundingClientRect().height;
+    document.body.style.cursor = this.cursorFor(edge);
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', this.onDocMove);
+    document.addEventListener('mouseup', this.onDocUp);
+  }
+
+  private handleDocMove(e: MouseEvent) {
+    if (!this.dragging) return;
+    if (this.activeEdge & ResizeEdge.BOTTOM) {
+      const h = Math.max(
+        MIN_HEIGHT_PX,
+        this.startHeight + e.clientY - this.startY
+      );
+      this.el.style.height = `${h}px`;
+    }
+  }
+
+  private handleDocUp(e: MouseEvent) {
+    if (!this.dragging) return;
+    this.dragging = false;
+    document.removeEventListener('mousemove', this.onDocMove);
+    document.removeEventListener('mouseup', this.onDocUp);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    this.el.style.cursor = '';
+    this.el.setAttribute('data-resize-edge', '');
+
+    if (this.activeEdge & ResizeEdge.BOTTOM) {
+      const h = Math.max(
+        MIN_HEIGHT_PX,
+        this.startHeight + e.clientY - this.startY
+      );
+      this.el.style.height = `${h}px`;
+      if (this.persistKey) persistHeight(this.persistKey, h);
+    }
+
+    if (this.activeEdge & ResizeEdge.RIGHT) {
+      const dx = e.clientX - this.startX;
+      if (dx > FULL_WIDTH_DRAG_THRESHOLD_PX) {
+        this.zone.run(() => this.fullWidthRequested.emit(true));
+      } else if (dx < -FULL_WIDTH_DRAG_THRESHOLD_PX) {
+        this.zone.run(() => this.fullWidthRequested.emit(false));
+      }
+    }
+
+    this.activeEdge = ResizeEdge.NONE;
+  }
+
+  private handleDblClick(e: MouseEvent) {
+    const edge = this.edgeAt(e);
+    if (edge === ResizeEdge.NONE) return;
+    if (edge & ResizeEdge.BOTTOM) {
+      this.el.style.height = '';
+      if (this.persistKey) removeHeight(this.persistKey);
+    }
+    if (edge & ResizeEdge.RIGHT) {
+      this.zone.run(() =>
+        this.fullWidthRequested.emit(
+          !this.el.classList.contains('full-width')
+        )
+      );
+    }
+  }
+}

--- a/tensorbored/webapp/widgets/edge_resize_module.ts
+++ b/tensorbored/webapp/widgets/edge_resize_module.ts
@@ -1,0 +1,22 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {CardEdgeResizeDirective} from './edge_resize_directive';
+
+@NgModule({
+  exports: [CardEdgeResizeDirective],
+  declarations: [CardEdgeResizeDirective],
+})
+export class EdgeResizeModule {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation for features / changes

The small resize tabs (browser-native CSS `resize: vertical` handles) in the bottom-right corner of chart containers are very hard to grab, especially on smaller cards. Users have to precisely target a tiny area to resize cards. This PR replaces that mechanism with full edge-based and corner-based resizing directly on the card wrapper, making it much easier to adjust card dimensions.

## Technical description of changes

### New: `CardEdgeResizeDirective` (`edge_resize_directive.ts`)
- Detects mouse proximity to card edges within an 8px zone
- **Bottom edge**: drag to resize card height smoothly in pixels (minimum 200px)
- **Right edge**: drag to resize width smoothly in pixels during drag; on release, snaps to the nearest grid column span (span 1, 2, 3, ..., or full-width `1/-1`)
- **Corner (bottom-right)**: both height and width simultaneously
- On drag start for width: sets explicit pixel width, clears grid-column, raises z-index so the card overlaps neighbors during the smooth drag
- On release: computes nearest column span from final pixel width, removes pixel overrides, applies `grid-column: span N`
- Double-click bottom edge resets height; double-click right edge resets column span to 1
- Both height and column span are persisted to `localStorage` (`_tb_card_sizes.v1`) and restored on init
- Runs event listeners outside Angular zone for performance
- Uses `const enum ResizeEdge` with bitwise operations

### Visual indicators
- Subtle `::after` pseudo-elements on `.card-space` and `.card-wrapper` show:
  - A 3px highlight bar on the bottom or right edge when hovering near them
  - A 12px triangle indicator in the corner when near the corner
- `edge-resizing-width` class adds a subtle shadow during width drag for visual feedback
- Indicators fade in with CSS transitions

### Removed: CSS `resize: vertical` and `persistResize`
- Removed `resize: vertical` from `.chart-container` in both scalar and superimposed card SCSS
- Removed now-unused `[persistResize]` from chart containers (data table containers retain theirs)
- These were the hard-to-grab native browser resize tabs

### Integration
- `[cardEdgeResize]` directive applied to `.card-space` in `card_grid_component.ng.html` (regular cards)
- `[cardEdgeResize]` directive applied to `.card-wrapper` in `superimposed_cards_view_component.ts` (superimposed cards)
- `EdgeResizeModule` imported in `MainViewModule`
- `columnSpanChanged` event handled in both `CardGridComponent` and `SuperimposedCardsViewComponent`
- Bazel `BUILD` updated for both widgets and main_view targets

## Screenshots of UI changes (or N/A)

N/A (cursor-based interaction — smooth pixel resize during drag, grid-snap on release, subtle edge highlights)

## Detailed steps to verify changes work correctly (as executed by you)

1. Open the time series dashboard with multiple scalar cards
2. Hover near the bottom edge of a card — cursor changes to `ns-resize`, subtle bar appears
3. Drag the bottom edge down/up — card height changes smoothly (pixel by pixel)
4. Release — new height is persisted (survives page reload)
5. Double-click the bottom edge — height resets to default
6. Hover near the right edge — cursor changes to `ew-resize`
7. Drag the right edge right — card width grows smoothly following the cursor, with a subtle shadow
8. Release — card snaps to nearest grid column span (clean grid alignment)
9. Drag right edge left — card shrinks smoothly, snaps to smaller span on release
10. Double-click right edge — span resets to 1
11. Hover near the bottom-right corner — cursor changes to `nwse-resize`
12. Drag the corner — height and width adjust simultaneously; width snaps on release
13. Repeat for superimposed cards — same behavior applies
14. Full lint passes (`yarn lint`)

## Alternate designs / implementations considered (or N/A)

- **Binary full-width toggle**: Initial implementation just toggled full-width on/off. Too jarring — no intermediate sizes.
- **Integer column-span snapping during drag**: Snapped to `span N` during drag. Still jumpy — columns are 335+ px wide, so changes are coarse.
- **Smooth pixel width during drag + grid-snap on release (chosen)**: Best of both worlds — smooth real-time feedback while dragging, clean grid-aligned result on release.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d3829a4-b2e7-4389-b884-a1c0897e5eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d3829a4-b2e7-4389-b884-a1c0897e5eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

