### PR TITLE
Sync upstream tensorflow/tensorboard master (3 commits) + extend refactors to TensorBored code

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -12,13 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 import {debuggerLoaded, debuggerUnloaded} from './actions';
 import {getActiveRunId, getDebuggerRunListing} from './store';
 import {State} from './store/debugger_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -401,9 +401,12 @@ describe('Debugger effects', () => {
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
-      dispatchedActions.push(action);
-    });
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    dispatchSpy = (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+      (action: Action) => {
+        dispatchedActions.push(action);
+      }
+    );
     store.overrideSelector(getActivePlugin, '');
   });
 
@@ -436,6 +439,7 @@ describe('Debugger effects', () => {
     begin: number,
     end: number,
     alertsResponse: AlertsResponse,
+    // tslint:disable-next-line:enforce-name-casing
     alert_type?: string
   ) {
     if (alert_type === undefined) {
@@ -1403,6 +1407,7 @@ describe('Debugger effects', () => {
       },
       begin: 0,
       end: 2,
+      // tslint:disable-next-line:enforce-name-casing
       alert_type: AlertType.INF_NAN_ALERT,
       per_type_alert_limit: 1000,
       alerts: [alert0, alert1],
@@ -1657,7 +1662,9 @@ describe('Debugger effects', () => {
         .withArgs(runId, fileIndex)
         .and.returnValue(
           of({
+            // tslint:disable-next-line:enforce-name-casing
             host_name: hostName,
+            // tslint:disable-next-line:enforce-name-casing
             file_path: filePath,
             lines,
           })

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, NgModule} from '@angular/core';
+import {ChangeDetectionStrategy, Component, NgModule} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {
   createInitialExecutionsState,
@@ -354,6 +354,7 @@ export function createState(
 // that use it.
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2',
   template: ``,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {AlertType} from '../../store/debugger_types';
 
 export interface AlertTypeDisplay {
@@ -23,6 +29,7 @@ export interface AlertTypeDisplay {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'alerts-component',
   templateUrl: './alerts_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {DebugTensorValue} from '../../store/debugger_types';
 
 const basicDebugInfoStyle = `
@@ -30,6 +30,7 @@ const basicDebugInfoStyle = `
 `;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-dtype',
   template: ` {{ dtype }} `,
@@ -41,6 +42,7 @@ export class DebugTensorDTypeComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-rank',
   template: ` {{ rank }}D `,
@@ -52,6 +54,7 @@ export class DebugTensorRankComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-shape',
   template: ` shape:{{ shapeString }} `,
@@ -75,6 +78,7 @@ export class DebugTensorShapeComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-numeric-breakdown',
   template: `
@@ -209,6 +213,7 @@ export class DebugTensorNumericBreakdownComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-has-inf-or-nan',
   template: `
@@ -247,6 +252,7 @@ export class DebugTensorHasInfOrNaNComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'debug-tensor-value',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.ts
@@ -12,11 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {Execution, TensorDebugMode} from '../../store/debugger_types';
 import {parseDebugTensorValue} from '../../store/debug_tensor_value';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'execution-data-component',
   templateUrl: './execution_data_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 import {getFocusedExecutionData} from '../../store';
 import {Execution, State, TensorDebugMode} from '../../store/debugger_types';
@@ -21,6 +21,7 @@ import {DTYPE_ENUM_TO_NAME} from '../../tf_dtypes';
 const UNKNOWN_DTYPE_NAME = 'Unknown dtype';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-execution-data',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {select, Store} from '@ngrx/store';
 import {graphOpFocused} from '../../actions';
 import {
@@ -23,6 +23,7 @@ import {
 import {State} from '../../store/debugger_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-graph',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.ts
@@ -13,10 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {GraphOpInfo} from '../../store/debugger_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'graph-op',
   templateUrl: 'graph_op_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 import {
   graphExecutionFocused,
@@ -27,6 +27,7 @@ import {
 import {State} from '../../store/debugger_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-graph-executions',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_component.ts
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'inactive-component',
   templateUrl: './inactive_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
@@ -12,13 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 
 // TODO(cais): Move to a separate file.
 export interface InactiveState {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-inactive',
   template: ` <inactive-component></inactive-component> `,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {SourceFileContent, StackFrame} from '../../store/debugger_types';
 
 /**
@@ -24,6 +24,7 @@ import {SourceFileContent, StackFrame} from '../../store/debugger_types';
  * displayed by this component.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'source-files-component',
   templateUrl: './source_files_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {State as OtherAppState} from '../../../../../webapp/app_state';
@@ -24,6 +24,7 @@ import {
 import {State as DebuggerState} from '../../store/debugger_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-source-files',
   template: `

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {
   AfterViewChecked,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -40,6 +41,7 @@ export interface StackFrameForDisplay {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'stack-trace-component',
   templateUrl: './stack_trace_component.ng.html',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 import {sourceLineFocused} from '../../actions';
 import {
@@ -25,6 +25,7 @@ import {CodeLocationType, State} from '../../store/debugger_types';
 import {StackFrameForDisplay} from './stack_trace_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tf-debugger-v2-stack-trace',
   template: `

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -59,7 +59,8 @@ describe('alert_effects', () => {
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     recordedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       recordedActions.push(action);
     });
   });

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -56,7 +56,8 @@ describe('alert snackbar', () => {
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     recordedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       recordedActions.push(action);
     });
     overlayContainer = TestBed.inject(OverlayContainer);

--- a/tensorboard/webapp/app_container.ts
+++ b/tensorboard/webapp/app_container.ts
@@ -12,9 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, ViewContainerRef} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewContainerRef,
+} from '@angular/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-webapp',
   templateUrl: './app_container.ng.html',

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -243,7 +243,8 @@ describe('app_routing_effects', () => {
     store.overrideSelector(getRehydratedDeepLinks, []);
     actualActions = [];
 
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       actualActions.push(action);
     });
 

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {fakeAsync, flush, TestBed, tick} from '@angular/core/testing';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, createAction, createSelector, props, Store} from '@ngrx/store';
@@ -48,7 +48,13 @@ import {
 } from '../types';
 import {AppRoutingEffects, TEST_ONLY} from './app_routing_effects';
 
-@Component({standalone: false, selector: 'test', template: '', jit: true})
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  standalone: false,
+  selector: 'test',
+  template: '',
+  jit: true,
+})
 class TestableComponent {}
 
 const testAction = createAction('[TEST] test action');

--- a/tensorboard/webapp/app_routing/route_config_test.ts
+++ b/tensorboard/webapp/app_routing/route_config_test.ts
@@ -13,13 +13,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createAction, props} from '@ngrx/store';
 import {RouteConfigs, RouteMatch} from './route_config';
 import {ConcreteRouteDef, RedirectionRouteDef} from './route_config_types';
 import {Navigation, RouteKind} from './types';
 
-@Component({standalone: false, selector: 'test', template: ''})
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  standalone: false,
+  selector: 'test',
+  template: '',
+})
 class TestableComponent {}
 
 function buildConcreteRouteDef(override: Partial<ConcreteRouteDef>) {

--- a/tensorboard/webapp/app_routing/route_config_types.ts
+++ b/tensorboard/webapp/app_routing/route_config_types.ts
@@ -12,10 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Type} from '@angular/core';
+import {Type} from '@angular/core';
+import {Action} from '@ngrx/store';
 import {DeepLinkProvider} from './deep_link_provider';
 import {RouteKind, SerializableQueryParams} from './types';
-import {Action} from '@ngrx/store';
 
 export interface ConcreteRouteDef {
   routeKind: RouteKind;
@@ -26,7 +26,7 @@ export interface ConcreteRouteDef {
   // Parameter has to be denoted with ":" prefix and "/" has to precede it.
   path: string;
 
-  ngComponent: Type<Component>;
+  ngComponent: Type<unknown>;
 
   // Redirect to this `path` if current navigation does not match any known
   // routes. Only one RouteConfig can have defaultRoute = true.

--- a/tensorboard/webapp/app_routing/route_registry_module.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
-  Component,
   Inject,
   ModuleWithProviders,
   NgModule,
@@ -28,10 +27,7 @@ import {RouteKind} from './types';
 @NgModule({})
 export class RouteRegistryModule {
   private readonly routeConfigs: RouteConfigs;
-  private readonly routeKindToNgComponent = new Map<
-    RouteKind,
-    Type<Component>
-  >();
+  private readonly routeKindToNgComponent = new Map<RouteKind, Type<unknown>>();
 
   constructor(
     @Optional() @Inject(ROUTE_CONFIGS_TOKEN) configsList: RouteDef[][]
@@ -67,7 +63,7 @@ export class RouteRegistryModule {
     return this.routeConfigs;
   }
 
-  getNgComponentByRouteKind(routeKind: RouteKind): Type<Component> | null {
+  getNgComponentByRouteKind(routeKind: RouteKind): Type<unknown> | null {
     return this.routeKindToNgComponent.get(routeKind) || null;
   }
 

--- a/tensorboard/webapp/app_routing/route_registry_module_test.ts
+++ b/tensorboard/webapp/app_routing/route_registry_module_test.ts
@@ -13,12 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {RouteRegistryModule} from './route_registry_module';
 import {RouteKind} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'experiment',
   template: 'I am experiment',
@@ -26,6 +27,7 @@ import {RouteKind} from './types';
 class Experiment {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'experiments',
   template: 'List of experiment',
@@ -33,6 +35,7 @@ class Experiment {}
 class Experiments {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'not_found',
   template: 'Unknown route',

--- a/tensorboard/webapp/app_routing/views/router_link_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_link_test.ts
@@ -81,7 +81,8 @@ describe('router_link', () => {
       AppRootProvider
     ) as TestableAppRootProvider;
 
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       actualDispatches.push(action);
     });
   });

--- a/tensorboard/webapp/app_routing/views/router_link_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_link_test.ts
@@ -13,7 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, DebugElement, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  Input,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -27,6 +33,7 @@ import {LocationModule} from '../location_module';
 import {RouterLinkDirectiveContainer} from './router_link_directive_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test',
   template: '<a [routerLink]="link">testable link</a>',
@@ -37,6 +44,7 @@ class TestableComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test-with-reset',
   template:

--- a/tensorboard/webapp/app_routing/views/router_outlet_component.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_component.ts
@@ -33,14 +33,14 @@ export class RouterOutletComponent implements OnChanges {
   @ViewChild('routeContainer', {static: true, read: ViewContainerRef})
   private readonly routeContainer!: ViewContainerRef;
 
-  @Input() activeNgComponent!: Type<Component> | null;
+  @Input() activeNgComponent!: Type<unknown> | null;
 
   ngOnChanges(changes: SimpleChanges) {
     const activeComponentChange = changes['activeNgComponent'];
     if (activeComponentChange) {
       this.routeContainer.clear();
       const componentType =
-        activeComponentChange.currentValue as Type<Component> | null;
+        activeComponentChange.currentValue as Type<unknown> | null;
       if (componentType) {
         this.routeContainer.createComponent(componentType);
       }

--- a/tensorboard/webapp/app_routing/views/router_outlet_test.ts
+++ b/tensorboard/webapp/app_routing/views/router_outlet_test.ts
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {BrowserDynamicTestingModule} from '@angular/platform-browser-dynamic/testing';
@@ -33,6 +37,7 @@ import {RouterOutletComponent} from './router_outlet_component';
 import {RouterOutletContainer} from './router_outlet_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'first',
   template: 'I am a test',
@@ -40,6 +45,7 @@ import {RouterOutletContainer} from './router_outlet_container';
 class FirstTestableComponent {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'second',
   template: 'I am inevitable',

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -111,7 +111,8 @@ describe('core_effects', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 
     recordedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       recordedActions.push(action);
     });
 

--- a/tensorboard/webapp/core/views/layout_test.ts
+++ b/tensorboard/webapp/core/views/layout_test.ts
@@ -88,7 +88,8 @@ describe('layout test', () => {
 
     dispatchedActions = [];
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       dispatchedActions.push(action);
     });
     store.overrideSelector(getSideBarWidthInPercent, 10);

--- a/tensorboard/webapp/core/views/layout_test.ts
+++ b/tensorboard/webapp/core/views/layout_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -30,6 +30,7 @@ import {
 import {LayoutContainer} from './layout_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'sidebar',
   template: `sidebar content`,
@@ -37,6 +38,7 @@ import {LayoutContainer} from './layout_container';
 class Sidebar {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'main',
   template: `main content`,
@@ -44,6 +46,7 @@ class Sidebar {}
 class Main {}
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-component',
   template: `

--- a/tensorboard/webapp/core/views/page_title_test.ts
+++ b/tensorboard/webapp/core/views/page_title_test.ts
@@ -12,7 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Store} from '@ngrx/store';
 import {MockStore} from '@ngrx/store/testing';
@@ -112,6 +116,7 @@ describe('page title test', () => {
 });
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'my-tester',
   template: ` <page-title></page-title> `,

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -12,7 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, OnInit, Type, ViewContainerRef} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  Type,
+  ViewContainerRef,
+} from '@angular/core';
 
 /**
  * A Component that defines a customization point. Ideal for use for small
@@ -68,6 +75,7 @@ import {Component, Input, OnInit, Type, ViewContainerRef} from '@angular/core';
  *    })
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-customization',
   template: `

--- a/tensorboard/webapp/customization/customizable_component.ts
+++ b/tensorboard/webapp/customization/customizable_component.ts
@@ -31,7 +31,7 @@ import {
  *
  * 1. Define a customizable Component, for example a button:
  *
- *    const CustomizableButton = new InjectionToken<Type<Component>>('Customizable Button');
+ *    const CustomizableButton = new InjectionToken<Type<unknown>>('Customizable Button');
  *
  * 2. Where the customization point is desired, use this Component to wrap some
  *    default behavior. Bind to some possibly-empty variable with the
@@ -46,7 +46,7 @@ import {
  *
  *    constructor(
  *      @Optional() @Inject(CustomizableButton)
- *      readonly customButtonIfProvided: Type<Component>)
+ *      readonly customButtonIfProvided: Type<unknown>)
  *
  * If you do not wish to customize the behavior for a certain TensorBoard
  * service (in this case, a button), you're done. The TensorBoard service
@@ -85,7 +85,7 @@ import {
   `,
 })
 export class CustomizableComponent implements OnInit {
-  @Input() customizableComponent!: Type<Component> | undefined;
+  @Input() customizableComponent!: Type<unknown> | undefined;
 
   constructor(private readonly viewContainerRef: ViewContainerRef) {}
 

--- a/tensorboard/webapp/customization/customization_test.ts
+++ b/tensorboard/webapp/customization/customization_test.ts
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, NgModule, Optional} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  Optional,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {CustomizationModule} from './customization_module';
 
@@ -26,6 +31,7 @@ export class CustomizableComponentType {}
  * Parent class that uses the <tb-customization> component.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'parent-component',
   template: `
@@ -55,6 +61,7 @@ export class ParentComponentModule {}
  * into the ParentComponent for some tests.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'customizable-component',
   template: ` <div>Showing Customized Text!</div> `,

--- a/tensorboard/webapp/feature_flag/directives/feature_flag_directive_test.ts
+++ b/tensorboard/webapp/feature_flag/directives/feature_flag_directive_test.ts
@@ -12,20 +12,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, DebugElement, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  Input,
+} from '@angular/core';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Store} from '@ngrx/store';
 import {MockStore} from '@ngrx/store/testing';
 
 import {provideMockTbStore} from '../../testing/utils';
-import {FEATURE_FLAGS_HEADER_NAME} from '../http/const';
 import {getFeatureFlagsToSendToServer} from '../store/feature_flag_selectors';
 import {State as FeatureFlagState} from '../store/feature_flag_types';
 
 import {FeatureFlagDirective} from './feature_flag_directive';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test-matching-selector',
   template: `
@@ -41,6 +46,7 @@ export class TestMatchingComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test-nonmatching-selector',
   template: `

--- a/tensorboard/webapp/feature_flag/views/feature_flag_dialog_component.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_dialog_component.ts
@@ -12,12 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {FeatureFlagType} from '../store/feature_flag_metadata';
 import {FeatureFlags} from '../types';
 import {FeatureFlagStatus, FeatureFlagStatusEvent} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'feature-flag-dialog-component',
   styleUrls: ['feature_flag_dialog_component.css'],

--- a/tensorboard/webapp/feature_flag/views/feature_flag_dialog_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_dialog_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {map, withLatestFrom} from 'rxjs/operators';
@@ -40,6 +40,7 @@ import {
 } from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'feature-flag-dialog',
   template: `<feature-flag-dialog-component

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container.ts
@@ -13,7 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ComponentType} from '@angular/cdk/overlay';
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {Store} from '@ngrx/store';
 import {Subject} from 'rxjs';
@@ -30,6 +35,7 @@ const util = {
 };
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'feature-flag-modal-trigger',
   template: ``,

--- a/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
+++ b/tensorboard/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
@@ -35,6 +35,7 @@ import {
 } from './feature_flag_modal_trigger_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-feature-flag-dialog-container',
   template: '<div>Test</div>',

--- a/tensorboard/webapp/header/dark_mode_toggle_component.ts
+++ b/tensorboard/webapp/header/dark_mode_toggle_component.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 
 export enum DarkModeOverride {
   DEFAULT,
@@ -21,6 +27,7 @@ export enum DarkModeOverride {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'app-header-dark-mode-toggle-component',
   template: `

--- a/tensorboard/webapp/header/dark_mode_toggle_container.ts
+++ b/tensorboard/webapp/header/dark_mode_toggle_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -23,6 +23,7 @@ import {State as FeatureFlagState} from '../feature_flag/store/feature_flag_type
 import {DarkModeOverride} from './dark_mode_toggle_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'app-header-dark-mode-toggle',
   template: `

--- a/tensorboard/webapp/header/dark_mode_toggle_test.ts
+++ b/tensorboard/webapp/header/dark_mode_toggle_test.ts
@@ -50,7 +50,8 @@ describe('dark mode toggle test', () => {
     store.overrideSelector(getEnableDarkModeOverride, null);
 
     dispatchedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       dispatchedActions.push(action);
     });
 

--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'app-header',
   template: `

--- a/tensorboard/webapp/header/plugin_selector_component.ts
+++ b/tensorboard/webapp/header/plugin_selector_component.ts
@@ -12,12 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {MatSelectChange} from '@angular/material/select';
 import {PluginId} from '../types/api';
 import {UiPluginMetadata} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'plugin-selector-component',
   templateUrl: './plugin_selector_component.ng.html',

--- a/tensorboard/webapp/header/plugin_selector_container.ts
+++ b/tensorboard/webapp/header/plugin_selector_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 import {changePlugin} from '../core/actions';
 import {getActivePlugin, getPlugins, State} from '../core/store';
@@ -29,6 +29,7 @@ const getDisabledPlugins = createSelector(
 );
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'plugin-selector',
   template: `

--- a/tensorboard/webapp/header/reload_container.ts
+++ b/tensorboard/webapp/header/reload_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 import {combineLatestWith, map} from 'rxjs/operators';
@@ -36,6 +36,7 @@ const isReloadDisabledByPlugin = createSelector(
 );
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'app-header-reload',
   template: `

--- a/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
+++ b/tensorboard/webapp/hparams/_redux/hparams_effects_test.ts
@@ -65,9 +65,12 @@ describe('hparams effects', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 
     actualActions = [];
-    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
-      actualActions.push(action);
-    });
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    dispatchSpy = (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+      (action: Action) => {
+        actualActions.push(action);
+      }
+    );
 
     effects = TestBed.inject(HparamsEffects);
     dataSource = TestBed.inject(

--- a/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
+++ b/tensorboard/webapp/metrics/effects/metrics_effects_test.ts
@@ -85,7 +85,8 @@ describe('metrics effects', () => {
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       actualActions.push(action);
     });
     effects = TestBed.inject(MetricsEffects);

--- a/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_lazy_loader_test.ts
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -25,6 +30,7 @@ import {CardId} from '../../types';
 import {CardLazyLoader, CardObserver} from '../card_renderer/card_lazy_loader';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'card-view',
   template: `{{ cardId }}`,
@@ -39,6 +45,7 @@ interface TestableCardConfig {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-cards',
   template: `

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -35,6 +36,7 @@ import {CardViewComponent} from './card_view_component';
 import {CardViewContainer} from './card_view_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'scalar-card',
   template: ``,

--- a/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/histogram_card_test.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {By} from '@angular/platform-browser';
@@ -58,6 +64,7 @@ import {RunNameModule} from './run_name_module';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-histogram',
   template: ``,

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
@@ -45,6 +45,7 @@ import {RunNameModule} from './run_name_module';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'card-view',
   template: `

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_line_chart_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -35,6 +36,7 @@ import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
 import * as selectors from '../../../selectors';
 import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {provideMockTbStore} from '../../../testing/utils';
 import {CardFobComponent} from '../../../widgets/card_fob/card_fob_component';
 import {
   CardFobControllerComponent,
@@ -54,6 +56,7 @@ import {
   relativeTimeFormatter,
   siNumberFormatter,
 } from '../../../widgets/line_chart_v2/lib/formatter';
+import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {
   DataSeries,
   DataSeriesMetadataMap,
@@ -69,22 +72,21 @@ import {
 } from '../../actions';
 import {getMetricsCardRangeSelectionEnabled} from '../../store';
 import {TooltipSort, XAxisType} from '../../types';
+import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {ScalarCardLineChartComponent} from './scalar_card_line_chart_component';
 import {ScalarCardLineChartContainer} from './scalar_card_line_chart_container';
-import {ScalarCardFobController} from './scalar_card_fob_controller';
 import {
   MinMaxStep,
   OriginalSeriesMetadata,
+  ScalarCardDataSeries,
   ScalarCardPoint,
   ScalarCardSeriesMetadata,
   ScalarCardSeriesMetadataMap,
-  ScalarCardDataSeries,
   SeriesType,
 } from './scalar_card_types';
-import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
-import {provideMockTbStore} from '../../../testing/utils';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'line-chart',
   template: `
@@ -166,6 +168,7 @@ class TestableLineChart {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test-scalar-card-line-chart',
   template: `

--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -30,7 +31,7 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
-import {MatDialogModule, MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogModule} from '@angular/material/dialog';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {By} from '@angular/platform-browser';
@@ -40,10 +41,16 @@ import {MockStore} from '@ngrx/store/testing';
 import {Observable, of, ReplaySubject} from 'rxjs';
 import {State} from '../../../app_state';
 import {ExperimentAlias} from '../../../experiments/types';
+import * as hparamsActions from '../../../hparams/_redux/hparams_actions';
+import * as hparamsSelectors from '../../../hparams/_redux/hparams_selectors';
+import {HparamFilter} from '../../../hparams/_redux/types';
+import * as runsSelectors from '../../../runs/store/runs_selectors';
 import {Run} from '../../../runs/store/runs_types';
 import {buildRun} from '../../../runs/store/testing';
 import * as selectors from '../../../selectors';
+import {getIsScalarColumnContextMenusEnabled} from '../../../selectors';
 import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {provideMockTbStore} from '../../../testing/utils';
 import {DataLoadState} from '../../../types/data';
 import {CardFobComponent} from '../../../widgets/card_fob/card_fob_component';
 import {
@@ -55,8 +62,23 @@ import {
   TimeSelectionAffordance,
   TimeSelectionToggleAffordance,
 } from '../../../widgets/card_fob/card_fob_types';
+import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
+import {ContentRowComponent} from '../../../widgets/data_table/content_row_component';
 import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
 import {DataTableModule} from '../../../widgets/data_table/data_table_module';
+import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
+import {
+  AddColumnEvent,
+  ColumnHeader,
+  ColumnHeaderType,
+  DataTableMode,
+  DomainType,
+  FilterAddedEvent,
+  IntervalFilter,
+  ReorderColumnEvent,
+  Side,
+  SortingOrder,
+} from '../../../widgets/data_table/types';
 import {ExperimentAliasModule} from '../../../widgets/experiment_alias/experiment_alias_module';
 import {IntersectionObserverTestingModule} from '../../../widgets/intersection_observer/intersection_observer_testing_module';
 import {
@@ -64,6 +86,7 @@ import {
   relativeTimeFormatter,
   siNumberFormatter,
 } from '../../../widgets/line_chart_v2/lib/formatter';
+import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
 import {
   DataSeries,
   DataSeriesMetadataMap,
@@ -76,13 +99,13 @@ import {ResizeDetectorTestingModule} from '../../../widgets/resize_detector_test
 import {TruncatedPathModule} from '../../../widgets/text/truncated_path_module';
 import {
   cardViewBoxChanged,
-  metricsCardFullSizeToggled,
-  metricsCardStateUpdated,
-  stepSelectorToggled,
-  timeSelectionChanged,
-  metricsSlideoutMenuOpened,
   dataTableColumnOrderChanged,
   dataTableColumnToggled,
+  metricsCardFullSizeToggled,
+  metricsCardStateUpdated,
+  metricsSlideoutMenuOpened,
+  stepSelectorToggled,
+  timeSelectionChanged,
 } from '../../actions';
 import {PluginType} from '../../data_source';
 import {
@@ -104,6 +127,7 @@ import {
   provideMockCardRunToSeriesData,
 } from '../../testing';
 import {TooltipSort, XAxisType} from '../../types';
+import * as commonSelectors from '../main_view/common_selectors';
 import {ScalarCardComponent} from './scalar_card_component';
 import {ScalarCardContainer} from './scalar_card_container';
 import {ScalarCardDataTable} from './scalar_card_data_table';
@@ -113,32 +137,10 @@ import {
   ScalarCardSeriesMetadata,
   SeriesType,
 } from './scalar_card_types';
-import {
-  AddColumnEvent,
-  ColumnHeader,
-  ColumnHeaderType,
-  DataTableMode,
-  DomainType,
-  FilterAddedEvent,
-  IntervalFilter,
-  ReorderColumnEvent,
-  Side,
-  SortingOrder,
-} from '../../../widgets/data_table/types';
 import {VisLinkedTimeSelectionWarningModule} from './vis_linked_time_selection_warning_module';
-import {Extent} from '../../../widgets/line_chart_v2/lib/public_types';
-import {provideMockTbStore} from '../../../testing/utils';
-import * as commonSelectors from '../main_view/common_selectors';
-import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
-import {ContentRowComponent} from '../../../widgets/data_table/content_row_component';
-import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
-import {HparamFilter} from '../../../hparams/_redux/types';
-import * as hparamsSelectors from '../../../hparams/_redux/hparams_selectors';
-import * as hparamsActions from '../../../hparams/_redux/hparams_actions';
-import * as runsSelectors from '../../../runs/store/runs_selectors';
-import {getIsScalarColumnContextMenusEnabled} from '../../../selectors';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'line-chart',
   template: `
@@ -223,6 +225,7 @@ class TestableLineChart {
 // DataDownloadContainer pulls in entire redux and, for this test, we don't want to
 // know about their data requirements.
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-data-download-dialog',
   template: `{{ cardId }}`,

--- a/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/card_grid_test.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {ScrollingModule} from '@angular/cdk/scrolling';
 import {
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -48,6 +49,7 @@ import {CardGridContainer} from './card_grid_container';
 const scrollElementHeight = 100;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-scrolling-container',
   template: `
@@ -82,7 +84,11 @@ class TestableScrollingContainer {
 /**
  * Stub 'card-view' component for ease of testing.
  */
-@Component({standalone: false, selector: 'card-view'})
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  standalone: false,
+  selector: 'card-view',
+})
 class TestableCardView {
   @Output() fullHeightChanged = new EventEmitter<boolean>();
   @Output() fullWidthChanged = new EventEmitter<boolean>();

--- a/tensorboard/webapp/metrics/views/main_view/main_view_component.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_component.ts
@@ -17,18 +17,18 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  Input,
   Inject,
+  InjectionToken,
+  Input,
+  Optional,
   Output,
   Type,
-  Optional,
-  InjectionToken,
 } from '@angular/core';
 
 import {PluginType} from '../../types';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 
-export const SHARE_BUTTON_COMPONENT = new InjectionToken<Type<Component>>(
+export const SHARE_BUTTON_COMPONENT = new InjectionToken<Type<unknown>>(
   'Customizable Share Button'
 );
 
@@ -62,7 +62,7 @@ export class MainViewComponent {
     private readonly host: ElementRef,
     @Optional()
     @Inject(SHARE_BUTTON_COMPONENT)
-    readonly customShareButton: Type<Component>
+    readonly customShareButton: Type<unknown>
   ) {
     this.cardObserver = new CardObserver(
       this.host.nativeElement,

--- a/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
+++ b/tensorboard/webapp/metrics/views/main_view/main_view_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   Component,
   DebugElement,
   Input,
@@ -39,6 +40,7 @@ import {
 } from '../../../selectors';
 import {selectors as settingsSelectors} from '../../../settings';
 import {KeyType, sendKey, sendKeys} from '../../../testing/dom';
+import {buildMockState} from '../../../testing/utils';
 import {DataLoadState} from '../../../types/data';
 import {RunColorScale} from '../../../types/ui';
 import * as actions from '../../actions';
@@ -53,25 +55,25 @@ import {CardLazyLoader, CardObserver} from '../card_renderer/card_lazy_loader';
 import {CardIdWithMetadata} from '../metrics_view_types';
 import {CardGridComponent} from './card_grid_component';
 import {CardGridContainer} from './card_grid_container';
-import {CardGroupsComponent} from './card_groups_component';
-import {CardGroupsContainer} from './card_groups_container';
 import {CardGroupToolBarComponent} from './card_group_toolbar_component';
 import {CardGroupToolBarContainer} from './card_group_toolbar_container';
+import {CardGroupsComponent} from './card_groups_component';
+import {CardGroupsContainer} from './card_groups_container';
 import * as common_selectors from './common_selectors';
 import {EmptyTagMatchMessageComponent} from './empty_tag_match_message_component';
 import {EmptyTagMatchMessageContainer} from './empty_tag_match_message_container';
 import {FilteredViewComponent} from './filtered_view_component';
 import {
-  FilteredViewContainer,
   FILTER_VIEW_DEBOUNCE_IN_MS,
+  FilteredViewContainer,
 } from './filtered_view_container';
 import {MainViewComponent, SHARE_BUTTON_COMPONENT} from './main_view_component';
 import {MainViewContainer} from './main_view_container';
 import {PinnedViewComponent} from './pinned_view_component';
 import {PinnedViewContainer} from './pinned_view_container';
-import {buildMockState} from '../../../testing/utils';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'card-view',
   template: `{{ pluginType }}: {{ cardId }}`,
@@ -83,6 +85,7 @@ class TestableCard {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test-share-button',
   template: ``,

--- a/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
+++ b/tensorboard/webapp/metrics/views/right_pane/scalar_column_editor/scalar_column_editor_test.ts
@@ -236,9 +236,12 @@ describe('scalar column editor', () => {
     let dispatchedActions: Action[] = [];
     beforeEach(() => {
       dispatchedActions = [];
-      spyOn(store, 'dispatch').and.callFake((action: Action) => {
-        dispatchedActions.push(action);
-      });
+      // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+      (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+        (action: Action) => {
+          dispatchedActions.push(action);
+        }
+      );
     });
 
     it('dispatches dataTableColumnToggled action with singe selection when checkbox is clicked', fakeAsync(() => {
@@ -320,9 +323,12 @@ describe('scalar column editor', () => {
     let dispatchedActions: Action[] = [];
     beforeEach(() => {
       dispatchedActions = [];
-      spyOn(store, 'dispatch').and.callFake((action: Action) => {
-        dispatchedActions.push(action);
-      });
+      // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+      (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+        (action: Action) => {
+          dispatchedActions.push(action);
+        }
+      );
     });
 
     it('dispatches dataTableColumnOrderChanged action with single selection when header is dragged', fakeAsync(() => {
@@ -508,9 +514,12 @@ describe('scalar column editor', () => {
     let dispatchedActions: Action[] = [];
     beforeEach(() => {
       dispatchedActions = [];
-      spyOn(store, 'dispatch').and.callFake((action: Action) => {
-        dispatchedActions.push(action);
-      });
+      // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+      (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+        (action: Action) => {
+          dispatchedActions.push(action);
+        }
+      );
     });
     it('dispatches metricsSlideoutMenuClosed', () => {
       const fixture = createComponent();
@@ -527,9 +536,12 @@ describe('scalar column editor', () => {
     let dispatchedActions: Action[] = [];
     beforeEach(() => {
       dispatchedActions = [];
-      spyOn(store, 'dispatch').and.callFake((action: Action) => {
-        dispatchedActions.push(action);
-      });
+      // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+      (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+        (action: Action) => {
+          dispatchedActions.push(action);
+        }
+      );
     });
     it('dispatches tableEditorTabChanged action when tab is clicked', fakeAsync(() => {
       const fixture = createComponent();

--- a/tensorboard/webapp/notification_center/_redux/notification_center_effects_test.ts
+++ b/tensorboard/webapp/notification_center/_redux/notification_center_effects_test.ts
@@ -60,7 +60,8 @@ describe('notification center effects', () => {
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       actualActions.push(action);
     });
     effects = TestBed.inject(NotificationCenterEffects);
@@ -96,7 +97,7 @@ describe('notification center effects', () => {
 
   it('dispatches failed action when notification fetch failed', () => {
     fetchNotificationsSpy.and.returnValue(
-      throwError(new Error('Request failed'))
+      throwError(() => new Error('Request failed'))
     );
     actions$.next(TEST_ONLY.initAction());
 

--- a/tensorboard/webapp/notification_center/_views/notification_center_component.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_component.ts
@@ -12,11 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {CategoryEnum} from '../_redux/notification_center_types';
 import {ViewNotificationExt} from './view_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'notification-center-component',
   templateUrl: './notification_center_component.ng.html',

--- a/tensorboard/webapp/notification_center/_views/notification_center_container.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {combineLatest, Observable} from 'rxjs';
 import {map, shareReplay} from 'rxjs/operators';
@@ -28,6 +28,7 @@ import {ViewNotificationExt} from './view_types';
 const iconMap = new Map([[CategoryEnum.WHATS_NEW, 'info_outline_24px']]);
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'notification-center',
   template: `

--- a/tensorboard/webapp/notification_center/_views/notification_center_test.ts
+++ b/tensorboard/webapp/notification_center/_views/notification_center_test.ts
@@ -52,7 +52,8 @@ describe('notification center', () => {
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     recordedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       recordedActions.push(action);
     });
     store.overrideSelector(selectors.getNotifications, []);

--- a/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
+++ b/tensorboard/webapp/persistent_settings/_redux/persistent_settings_effects_test.ts
@@ -78,9 +78,12 @@ describe('persistent_settings effects test', () => {
     }).compileComponents();
 
     store = TestBed.inject<Store<any>>(Store) as MockStore<any>;
-    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
-      actualActions.push(action);
-    });
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    dispatchSpy = (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+      (action: Action) => {
+        actualActions.push(action);
+      }
+    );
     effects = TestBed.inject(PersistentSettingsEffects);
     const dataSource = TestBed.inject(PersistentSettingsTestingDataSource);
     getSettingsSpy = spyOn(dataSource, 'getSettings').and.returnValue(of({}));

--- a/tensorboard/webapp/plugins/plugin_registry_module.ts
+++ b/tensorboard/webapp/plugins/plugin_registry_module.ts
@@ -13,16 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
-  Component,
   Inject,
   ModuleWithProviders,
   NgModule,
   Optional,
   Type,
 } from '@angular/core';
-import {PluginConfig, PLUGIN_CONFIG_TOKEN} from './plugin_registry_types';
+import {PLUGIN_CONFIG_TOKEN, PluginConfig} from './plugin_registry_types';
 
-const pluginNameToComponent = new Map<string, Type<Component>>();
+const pluginNameToComponent = new Map<string, Type<unknown>>();
 
 @NgModule({})
 export class PluginRegistryModule {
@@ -40,7 +39,7 @@ export class PluginRegistryModule {
 
     for (const config of configs) {
       const {pluginName, componentClass} = config;
-      pluginNameToComponent.set(pluginName, componentClass as Type<Component>);
+      pluginNameToComponent.set(pluginName, componentClass as Type<unknown>);
     }
   }
 
@@ -71,7 +70,7 @@ export class PluginRegistryModule {
     };
   }
 
-  getComponent(pluginName: string): Type<Component> | null {
+  getComponent(pluginName: string): Type<unknown> | null {
     return pluginNameToComponent.get(pluginName) || null;
   }
 }

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -37,8 +37,8 @@ import {
   LoadingMechanismType,
 } from '../types/api';
 import {DataLoadState} from '../types/data';
-import {UiPluginMetadata} from './plugins_container';
 import {PluginRegistryModule} from './plugin_registry_module';
+import {UiPluginMetadata} from './plugins_container';
 
 interface PolymerDashboard extends HTMLElement {
   reload?: () => void;

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Store} from '@ngrx/store';
@@ -47,9 +47,9 @@ import {
   PluginId,
 } from '../types/api';
 import {DataLoadState} from '../types/data';
+import {PluginRegistryModule} from './plugin_registry_module';
 import {PluginsComponent} from './plugins_component';
 import {PluginsContainer} from './plugins_container';
-import {PluginRegistryModule} from './plugin_registry_module';
 import {ExtraDashboardModule} from './testing';
 
 function expectPluginIframe(element: HTMLElement, name: string) {
@@ -64,6 +64,7 @@ function expectPluginIframe(element: HTMLElement, name: string) {
  * the `plugins` component.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   template: `
     <ng-template #environmentFailureNotFoundTemplate>

--- a/tensorboard/webapp/plugins/testing/index.ts
+++ b/tensorboard/webapp/plugins/testing/index.ts
@@ -12,10 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, NgModule} from '@angular/core';
+import {ChangeDetectionStrategy, Component, NgModule} from '@angular/core';
 import {PluginRegistryModule} from '../plugin_registry_module';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'extra-dashboard',
   template: ` <div>I'm the extra Angular dashboard!</div> `,

--- a/tensorboard/webapp/routes/index.ts
+++ b/tensorboard/webapp/routes/index.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Type} from '@angular/core';
+import {Type} from '@angular/core';
 import {RouteDef} from '../app_routing/route_config_types';
 import {RouteKind} from '../app_routing/types';
 import {TensorBoardWrapperComponent} from '../tb_wrapper/tb_wrapper_component';
@@ -23,7 +23,7 @@ export function routesFactory(): RouteDef[] {
     {
       routeKind: RouteKind.EXPERIMENT,
       path: '/',
-      ngComponent: TensorBoardWrapperComponent as Type<Component>,
+      ngComponent: TensorBoardWrapperComponent as Type<unknown>,
       defaultRoute: true,
       deepLinkProvider: new DashboardDeepLinkProvider(),
     },

--- a/tensorboard/webapp/runs/effects/runs_effects_test.ts
+++ b/tensorboard/webapp/runs/effects/runs_effects_test.ts
@@ -91,7 +91,8 @@ describe('runs_effects', () => {
     selectSpy = spyOn(store, 'select').and.callThrough();
 
     actualActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       actualActions.push(action);
     });
     effects = TestBed.inject(RunsEffects);

--- a/tensorboard/webapp/runs/views/runs_table/filterbar_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/filterbar_test.ts
@@ -12,32 +12,36 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, NO_ERRORS_SCHEMA} from '@angular/core';
-import {FilterbarComponent} from './filterbar_component';
-import {FilterbarContainer} from './filterbar_container';
+import {MatChipRemove, MatChipsModule} from '@angular/material/chips';
+import {MatChipHarness} from '@angular/material/chips/testing';
+import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {provideMockTbStore} from '../../../testing/utils';
+import {Action, Store} from '@ngrx/store';
 import {MockStore} from '@ngrx/store/testing';
 import {State} from '../../../app_state';
-import {Action, Store} from '@ngrx/store';
-import {By} from '@angular/platform-browser';
 import {
   actions as hparamsActions,
   selectors as hparamsSelectors,
 } from '../../../hparams';
+import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {provideMockTbStore} from '../../../testing/utils';
+import {CustomModal} from '../../../widgets/custom_modal/custom_modal';
+import {FilterDialog} from '../../../widgets/data_table/filter_dialog_component';
+import {FilterDialogModule} from '../../../widgets/data_table/filter_dialog_module';
 import {
+  DiscreteFilter,
   DomainType,
   IntervalFilter,
-  DiscreteFilter,
 } from '../../../widgets/data_table/types';
-import {MatChipHarness} from '@angular/material/chips/testing';
-import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {MatChipRemove, MatChipsModule} from '@angular/material/chips';
-import {MatIconTestingModule} from '../../../testing/mat_icon_module';
-import {FilterDialogModule} from '../../../widgets/data_table/filter_dialog_module';
-import {FilterDialog} from '../../../widgets/data_table/filter_dialog_component';
-import {CustomModal} from '../../../widgets/custom_modal/custom_modal';
+import {FilterbarComponent} from './filterbar_component';
+import {FilterbarContainer} from './filterbar_container';
 
 const discreteFilter: DiscreteFilter = {
   type: DomainType.DISCRETE,
@@ -61,6 +65,7 @@ const fakeFilterMap = new Map<string, DiscreteFilter | IntervalFilter>([
 ]);
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-component',
   template: ` <filterbar></filterbar> `,

--- a/tensorboard/webapp/runs/views/runs_table/filterbar_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/filterbar_test.ts
@@ -100,9 +100,12 @@ describe('hparam_filterbar', () => {
   function createComponent(): ComponentFixture<TestableComponent> {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     actualActions = [];
-    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
-      actualActions.push(action);
-    });
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    dispatchSpy = (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+      (action: Action) => {
+        actualActions.push(action);
+      }
+    );
 
     const fixture = TestBed.createComponent(TestableComponent);
     return fixture;

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_container.ts
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, inject} from '@angular/core';
-import {MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {Store} from '@ngrx/store';
 import {combineLatest, defer, merge, Observable, Subject} from 'rxjs';
 import {
@@ -28,17 +28,17 @@ import {
 import {State} from '../../../app_state';
 import {
   getDarkModeEnabled,
+  getDashboardExperimentNames,
   getEnableColorByExperiment,
 } from '../../../selectors';
 import {selectors as settingsSelectors} from '../../../settings/';
 import {runGroupByChanged} from '../../actions';
 import {
   getColorGroupRegexString,
-  getRunIdsForExperiment,
   getRunGroupBy,
+  getRunIdsForExperiment,
   getRuns,
 } from '../../store/runs_selectors';
-import {getDashboardExperimentNames} from '../../../selectors';
 import {groupRuns} from '../../store/utils';
 import {GroupByKey, Run} from '../../types';
 import {ColorGroup} from './regex_edit_dialog_component';
@@ -46,6 +46,7 @@ import {ColorGroup} from './regex_edit_dialog_component';
 const INPUT_CHANGE_DEBOUNCE_INTERVAL_MS = 500;
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'regex-edit-dialog',
   template: `<regex-edit-dialog-component

--- a/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/regex_edit_dialog_test.ts
@@ -100,9 +100,12 @@ describe('regex_edit_dialog', () => {
     });
     store.overrideSelector(getEnableColorByExperiment, true);
     actualActions = [];
-    dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
-      actualActions.push(action);
-    });
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    dispatchSpy = (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake(
+      (action: Action) => {
+        actualActions.push(action);
+      }
+    );
 
     return TestBed.createComponent(RegexEditDialogContainer);
   }

--- a/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_data_table_test.ts
@@ -13,27 +13,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-import {RunsDataTable} from './runs_data_table';
-import {DataTableModule} from '../../../widgets/data_table/data_table_module';
-import {MatIconTestingModule} from '../../../testing/mat_icon_module';
-import {MatCheckboxModule} from '@angular/material/checkbox';
 import {
-  SortingOrder,
-  SortingInfo,
-  TableData,
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+  ViewChild,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {By} from '@angular/platform-browser';
+import {sendKeys} from '../../../testing/dom';
+import {MatIconTestingModule} from '../../../testing/mat_icon_module';
+import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
+import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
+import {DataTableModule} from '../../../widgets/data_table/data_table_module';
+import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
+import {
   ColumnHeader,
   ColumnHeaderType,
+  SortingInfo,
+  SortingOrder,
+  TableData,
 } from '../../../widgets/data_table/types';
-import {By} from '@angular/platform-browser';
-import {HeaderCellComponent} from '../../../widgets/data_table/header_cell_component';
-import {DataTableComponent} from '../../../widgets/data_table/data_table_component';
-import {ContentCellComponent} from '../../../widgets/data_table/content_cell_component';
 import {FilterInputModule} from '../../../widgets/filter_input/filter_input_module';
-import {sendKeys} from '../../../testing/dom';
+import {RunsDataTable} from './runs_data_table';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_component.ts
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_component.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -26,6 +27,7 @@ interface PolymerChangeEvent extends CustomEvent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-legacy-runs-selector-component',
   template: ` <tf-runs-selector #selector></tf-runs-selector> `,

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_container.ts
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_container.ts
@@ -12,12 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {State} from '../../../app_state';
 import {polymerInteropRunSelectionChanged} from '../../../core/actions';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-legacy-runs-selector',
   template: `

--- a/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
+++ b/tensorboard/webapp/runs_legacy/views/legacy_runs_selector/legacy_runs_selector_test.ts
@@ -43,7 +43,8 @@ describe('legacy_runs_selector test', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 
     recordedActions = [];
-    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+    // Cast to jasmine.Spy for compatibility between NgRx dispatch signature overloads.
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.callFake((action: Action) => {
       recordedActions.push(action);
     });
 

--- a/tensorboard/webapp/settings/_views/settings_button_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_button_component.ts
@@ -12,12 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {DataLoadState} from '../../types/data';
 import {SettingsDialogContainer} from './settings_dialog_container';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'settings-button-component',
   template: `

--- a/tensorboard/webapp/settings/_views/settings_button_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_button_container.ts
@@ -12,12 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {getSettingsLoadState} from '../_redux/settings_selectors';
 import {State} from '../_redux/settings_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'settings-button',
   template: `

--- a/tensorboard/webapp/settings/_views/settings_dialog_component.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_component.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -41,6 +42,7 @@ export function createIntegerValidator(): ValidatorFn {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'settings-dialog-component',
   templateUrl: 'settings_dialog_component.ng.html',

--- a/tensorboard/webapp/settings/_views/settings_dialog_container.ts
+++ b/tensorboard/webapp/settings/_views/settings_dialog_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {
   changePageSize,
@@ -27,6 +27,7 @@ import {
 import {State} from '../_redux/settings_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'settings-dialog',
   template: `

--- a/tensorboard/webapp/testing/integration_test_module.ts
+++ b/tensorboard/webapp/testing/integration_test_module.ts
@@ -17,7 +17,7 @@ limitations under the License.
  *
  * This module does not facilitate any screenshot testing.
  */
-import {Component, NgModule} from '@angular/core';
+import {ChangeDetectionStrategy, Component, NgModule} from '@angular/core';
 import {EffectsModule as NgrxEffectsModule} from '@ngrx/effects';
 import {StoreModule as NgrxStoreModule} from '@ngrx/store';
 import {AppRoutingModule} from '../app_routing/app_routing_module';
@@ -31,6 +31,7 @@ import {RunsModule} from '../runs/runs_module';
 import {MatIconTestingModule} from './mat_icon_module';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test',
   template: 'hello',

--- a/tensorboard/webapp/testing/mat_icon_module.ts
+++ b/tensorboard/webapp/testing/mat_icon_module.ts
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, NgModule} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+} from '@angular/core';
 import {MatIconRegistry} from '@angular/material/icon';
 import {FakeMatIconRegistry} from '@angular/material/icon/testing';
 
@@ -74,6 +79,7 @@ const KNOWN_SVG_ICON = new Set([
  * compilation time due to unknown input onto the template.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   template: '<ng-container>{{svgIcon}}</ng-container>',
   selector: 'mat-icon',

--- a/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_controller_test.ts
@@ -13,7 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CardFobComponent} from './card_fob_component';
@@ -27,6 +33,7 @@ import {
 } from './card_fob_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/card_fob/card_fob_test.ts
+++ b/tensorboard/webapp/widgets/card_fob/card_fob_test.ts
@@ -13,13 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {CardFobComponent} from './card_fob_component';
 import {AxisDirection} from './card_fob_types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-fob-comp',
   template: `

--- a/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_test.ts
+++ b/tensorboard/webapp/widgets/content_wrapping_input/content_wrapping_input_test.ts
@@ -13,13 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {KeyType, sendKey} from '../../testing/dom';
 import {ContentWrappingInputComponent} from './content_wrapping_input_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testing-component',
   template: `

--- a/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
+++ b/tensorboard/webapp/widgets/custom_modal/custom_modal_test.ts
@@ -12,6 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {Overlay, OverlayModule, OverlayRef} from '@angular/cdk/overlay';
+import {CommonModule} from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
 import {
   ComponentFixture,
   TestBed,
@@ -19,18 +28,11 @@ import {
   tick,
 } from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {CustomModal} from './custom_modal';
-import {CommonModule} from '@angular/common';
-import {
-  Component,
-  TemplateRef,
-  ViewChild,
-  ViewContainerRef,
-} from '@angular/core';
-import {Overlay, OverlayModule, OverlayRef} from '@angular/cdk/overlay';
 import {first} from 'rxjs/operators';
+import {CustomModal} from './custom_modal';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'fake-modal-view-container',
   template: `

--- a/tensorboard/webapp/widgets/data_table/content_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/content_cell_component_test.ts
@@ -13,15 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {By} from '@angular/platform-browser';
-import {ColumnHeader, ColumnHeaderType} from './types';
-import {DataTableModule} from './data_table_module';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {ContentCellComponent} from './content_cell_component';
+import {DataTableModule} from './data_table_module';
+import {ColumnHeader, ColumnHeaderType} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/data_table/data_table_test.ts
+++ b/tensorboard/webapp/widgets/data_table/data_table_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {
   ApplicationRef,
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -22,32 +23,33 @@ import {
   ViewChild,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatIconTestingModule} from '../../testing/mat_icon_module';
 import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
+import {CustomModal} from '../custom_modal/custom_modal';
+import {ColumnSelectorComponent} from './column_selector_component';
+import {ColumnSelectorModule} from './column_selector_module';
+import {ContentCellComponent} from './content_cell_component';
+import {DataTableComponent} from './data_table_component';
+import {DataTableModule} from './data_table_module';
+import {FilterDialog} from './filter_dialog_component';
+import {HeaderCellComponent} from './header_cell_component';
 import {
   ColumnHeader,
   ColumnHeaderType,
-  TableData,
+  DiscreteFilter,
+  DomainType,
+  IntervalFilter,
+  Side,
   SortingInfo,
   SortingOrder,
-  DiscreteFilter,
-  IntervalFilter,
-  DomainType,
-  Side,
+  TableData,
 } from './types';
-import {DataTableComponent} from './data_table_component';
-import {DataTableModule} from './data_table_module';
-import {HeaderCellComponent} from './header_cell_component';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {ColumnSelectorComponent} from './column_selector_component';
-import {ContentCellComponent} from './content_cell_component';
-import {ColumnSelectorModule} from './column_selector_module';
-import {FilterDialog} from './filter_dialog_component';
-import {CustomModal} from '../custom_modal/custom_modal';
 
 const ADD_BUTTON_PREDICATE = By.css('.add-button');
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/data_table/filter_dialog_component.ts
+++ b/tensorboard/webapp/widgets/data_table/filter_dialog_component.ts
@@ -12,16 +12,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {
-  DomainType,
-  DiscreteFilter,
-  IntervalFilter,
-  DiscreteFilterValue,
-} from './types';
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {RangeValues} from '../range_input/types';
+import {
+  DiscreteFilter,
+  DiscreteFilterValue,
+  DomainType,
+  IntervalFilter,
+} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-data-table-filter',
   templateUrl: 'filter_dialog_component.ng.html',

--- a/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
+++ b/tensorboard/webapp/widgets/data_table/header_cell_component_test.ts
@@ -13,25 +13,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
 import {
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  flush,
-} from '@angular/core/testing';
-import {MatIconTestingModule} from '../../testing/mat_icon_module';
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
+import {MatIconTestingModule} from '../../testing/mat_icon_module';
+import {DataTableModule} from './data_table_module';
+import {HeaderCellComponent} from './header_cell_component';
 import {
   ColumnHeader,
   ColumnHeaderType,
   SortingInfo,
   SortingOrder,
 } from './types';
-import {DataTableModule} from './data_table_module';
-import {HeaderCellComponent} from './header_cell_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_component.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 
 export interface DropdownOption {
   value: any;
@@ -31,6 +37,7 @@ export interface DropdownOption {
  * A generic dropdown with options, similar to <select>.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-dropdown',
   template: `

--- a/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
+++ b/tensorboard/webapp/widgets/dropdown/dropdown_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatSelectModule} from '@angular/material/select';
 import {MatSelectHarness} from '@angular/material/select/testing';
@@ -25,6 +25,7 @@ import {DropdownComponent, DropdownOption} from './dropdown_component';
  * Test class that uses the <tb-dropdown> component.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testing-component',
   template: `

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_component.ts
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
 import {ExperimentAlias} from '../../experiments/types';
 
 /**
@@ -20,6 +26,7 @@ import {ExperimentAlias} from '../../experiments/types';
  * this experiment from others.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-experiment-alias',
   template: `

--- a/tensorboard/webapp/widgets/experiment_alias/experiment_alias_test.ts
+++ b/tensorboard/webapp/widgets/experiment_alias/experiment_alias_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ExperimentAlias} from '../../experiments/types';
@@ -21,6 +21,7 @@ import {ContentWrappingInputModule} from '../content_wrapping_input/content_wrap
 import {ExperimentAliasComponent} from './experiment_alias_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable',
   template: `<tb-experiment-alias

--- a/tensorboard/webapp/widgets/filter_input/filter_input_component.ts
+++ b/tensorboard/webapp/widgets/filter_input/filter_input_component.ts
@@ -12,13 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  ViewChild,
+} from '@angular/core';
 import {MatAutocompleteTrigger} from '@angular/material/autocomplete';
 
 /**
  * A text input field intended for filtering items.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-filter-input',
   template: `

--- a/tensorboard/webapp/widgets/filter_input/filter_input_test.ts
+++ b/tensorboard/webapp/widgets/filter_input/filter_input_test.ts
@@ -13,17 +13,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {KeyType, sendKey} from '../../testing/dom';
-import {getAutocompleteOptions} from '../../testing/material';
 import {MatIconTestingModule} from '../../testing/mat_icon_module';
+import {getAutocompleteOptions} from '../../testing/material';
 import {FilterInputModule} from './filter_input_module';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test',
   template: `
@@ -46,6 +47,7 @@ class TestableInputWithCompletions {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'test',
   template: ` <tb-filter-input></tb-filter-input> `,

--- a/tensorboard/webapp/widgets/histogram/histogram_test.ts
+++ b/tensorboard/webapp/widgets/histogram/histogram_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   Component,
   DebugElement,
   Input,
@@ -66,6 +67,7 @@ function buildHistogramDatum(
 // Wrapper component required to properly trigger Angular lifecycles.
 // Without it, ngOnChanges do not get triggered before ngOnInit.
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-tb-histogram',
   template: `

--- a/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
+++ b/tensorboard/webapp/widgets/intersection_observer/intersection_observer_test.ts
@@ -14,11 +14,18 @@ limitations under the License.
 ==============================================================================*/
 
 import {ScrollingModule} from '@angular/cdk/scrolling';
-import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  ViewChild,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {IntersectionObserverDirective} from './intersection_observer_directive';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testing-component',
   template: `

--- a/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/line_chart_component_test.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -38,6 +39,7 @@ import {buildMetadata, buildSeries} from './lib/testing';
 import {LineChartComponent} from './line_chart_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'line-chart-grid-view',
   template: ``,
@@ -51,6 +53,7 @@ class FakeGridComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -15,7 +15,12 @@ limitations under the License.
 import {OverlayContainer, OverlayModule} from '@angular/cdk/overlay';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {CommonModule} from '@angular/common';
-import {Component, DebugElement, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  Input,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {MatInputModule} from '@angular/material/input';
@@ -30,6 +35,7 @@ import {AxisUtils} from './line_chart_axis_utils';
 import {LineChartAxisComponent} from './line_chart_axis_view';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
@@ -13,7 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, DebugElement, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DebugElement,
+  Input,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Extent, ScaleType} from '../lib/public_types';
@@ -21,6 +26,7 @@ import {createScale} from '../lib/scale';
 import {LineChartGridView} from './line_chart_grid_view';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_interactive_view_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import {OverlayContainer, OverlayModule} from '@angular/cdk/overlay';
 import {CommonModule} from '@angular/common';
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {
@@ -38,6 +38,7 @@ interface Coord {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-comp',
   template: `

--- a/tensorboard/webapp/widgets/markdown_renderer/markdown_renderer_component_test.ts
+++ b/tensorboard/webapp/widgets/markdown_renderer/markdown_renderer_component_test.ts
@@ -14,7 +14,13 @@ limitations under the License.
 ==============================================================================*/
 
 import {CommonModule} from '@angular/common';
-import {Component, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+  ViewChild,
+} from '@angular/core';
 import {
   ComponentFixture,
   fakeAsync,
@@ -24,6 +30,7 @@ import {
 import {MarkdownRendererComponent} from './markdown_renderer_component';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-markdown-renderer',
   template: `<markdown-renderer [markdown]="content"> </markdown-renderer>`,

--- a/tensorboard/webapp/widgets/range_input/range_input_test.ts
+++ b/tensorboard/webapp/widgets/range_input/range_input_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, DebugElement, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule} from '@angular/forms';
 import {MatSliderModule} from '@angular/material/slider';
@@ -22,6 +22,7 @@ import {RangeInputComponent} from './range_input_component';
 import {RangeInputSource, RangeValues} from './types';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-range-input',
   template: `

--- a/tensorboard/webapp/widgets/resize_detector_test.ts
+++ b/tensorboard/webapp/widgets/resize_detector_test.ts
@@ -13,11 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {ResizeDetectorDirective} from './resize_detector_directive';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testing-component',
   template: `

--- a/tensorboard/webapp/widgets/source_code/source_code_container.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
 import {from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {MonacoShim} from './load_monaco_shim';
@@ -30,6 +30,7 @@ import {MonacoShim} from './load_monaco_shim';
  * time.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'source-code',
   template: `

--- a/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_container_test.ts
@@ -15,7 +15,12 @@ limitations under the License.
 /**
  * Unit tests for the the Source Files component and container.
  */
-import {Component, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MonacoShim} from './load_monaco_shim';
 import {SourceCodeComponent} from './source_code_component';
@@ -23,6 +28,7 @@ import {SourceCodeContainer} from './source_code_container';
 import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-component',
   template: `

--- a/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
+++ b/tensorboard/webapp/widgets/source_code/source_code_diff_container_test.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
@@ -26,6 +27,7 @@ import {fakes, setUpMonacoFakes, spies, tearDownMonacoFakes} from './testing';
 
 // Does not use OnPush change detector, making it easier to test with.
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'testable-component',
   template: `

--- a/tensorboard/webapp/widgets/text/truncated_path_component.ts
+++ b/tensorboard/webapp/widgets/text/truncated_path_component.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 /**
  * A component for rendering a '/' delimited path. When text exceeds its
@@ -21,6 +21,7 @@ import {Component, Input} from '@angular/core';
  * ellipsis.
  */
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'tb-truncated-path',
   template: `

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -42,7 +42,7 @@ describe('Debugger Container', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   it('renders debugger component initially with inactive component', () => {

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -63,7 +63,7 @@ describe('Alerts Container', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   it('renders number of alerts and breakdown: no alerts', () => {

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
@@ -51,7 +51,7 @@ describe('Execution Data Container', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   it('CURT_HEALTH TensorDebugMode, One Output', () => {

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_container_test.ts
@@ -53,7 +53,7 @@ describe('Graph Container', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   afterEach(() => {

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -185,7 +185,7 @@ describe('Graph Executions Container', () => {
     fixture.autoDetectChanges();
     tick();
 
-    const dispatchSpy = spyOn(store, 'dispatch');
+    const dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
     const tensorNames = fixture.debugElement.queryAll(By.css('.tensor-name'));
     expect(tensorNames.length).toBe(2);
     tensorNames[0].nativeElement.click();

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -70,7 +70,7 @@ describe('Source Files Container', () => {
       providers: [provideMockTbStore(), DebuggerContainer],
     }).compileComponents();
     store = TestBed.inject<Store<AppState>>(Store) as MockStore<AppState>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
     store.overrideSelector(getDarkModeEnabled, false);
   });
 

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container_test.ts
@@ -55,7 +55,7 @@ describe('Stack Trace container', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   afterEach(() => {

--- a/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
+++ b/tensorbored/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
@@ -88,7 +88,7 @@ describe('Timeline Container', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   afterEach(() => {

--- a/tensorbored/webapp/core/views/hash_storage_test.ts
+++ b/tensorbored/webapp/core/views/hash_storage_test.ts
@@ -54,7 +54,7 @@ describe('hash storage test', () => {
       declarations: [HashStorageContainer, HashStorageComponent],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
 
     const deepLinker = TestBed.inject(DeepLinkerInterface);
     setPluginIdSpy = spyOn(deepLinker, 'setPluginId');

--- a/tensorbored/webapp/deeplink/hash_test.ts
+++ b/tensorbored/webapp/deeplink/hash_test.ts
@@ -28,7 +28,7 @@ describe('hash storage test', () => {
       declarations: [HashStorageContainer, HashStorageComponent],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
 
     setStringSpy = jasmine.createSpy();
     getStringSpy = jasmine.createSpy();

--- a/tensorbored/webapp/feature_flag/views/feature_flag_dialog_test.ts
+++ b/tensorbored/webapp/feature_flag/views/feature_flag_dialog_test.ts
@@ -61,7 +61,7 @@ describe('feature_flag_dialog_container', () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   afterEach(() => {

--- a/tensorbored/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
+++ b/tensorbored/webapp/feature_flag/views/feature_flag_modal_trigger_container_test.ts
@@ -56,7 +56,7 @@ describe('feature_flag_modal_trigger_container', () => {
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 
-    spyOn(store, 'dispatch').and.stub();
+    (spyOn(store, 'dispatch') as jasmine.Spy).and.stub();
 
     // Fake out window.location.reload so it doesn't do anything.
     TEST_ONLY.util.reloadWindow = () => {};

--- a/tensorbored/webapp/header/build_badge_component.ts
+++ b/tensorbored/webapp/header/build_badge_component.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {catchError, of} from 'rxjs';
 
@@ -23,6 +23,7 @@ interface BuildInfo {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   standalone: false,
   selector: 'build-badge',
   template: `

--- a/tensorbored/webapp/header/header_test.ts
+++ b/tensorbored/webapp/header/header_test.ts
@@ -153,7 +153,7 @@ describe('header test', () => {
   });
 
   it('fires an action when a tab is clicked', async () => {
-    const dispatch = spyOn(store, 'dispatch');
+    const dispatch = spyOn(store, 'dispatch') as jasmine.Spy;
     const fixture = TestBed.createComponent(HeaderComponent);
     fixture.detectChanges();
 
@@ -168,7 +168,7 @@ describe('header test', () => {
 
   describe('reload', () => {
     it('dispatches manual reload when clicking on the reload button', () => {
-      const dispatch = spyOn(store, 'dispatch');
+      const dispatch = spyOn(store, 'dispatch') as jasmine.Spy;
       const fixture = TestBed.createComponent(HeaderComponent);
       fixture.detectChanges();
 

--- a/tensorbored/webapp/metrics/views/right_pane/right_pane_test.ts
+++ b/tensorbored/webapp/metrics/views/right_pane/right_pane_test.ts
@@ -70,7 +70,7 @@ describe('metrics right_pane', () => {
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
     overlayContainer = TestBed.inject(OverlayContainer);
   });
 

--- a/tensorbored/webapp/reloader/reloader_component_test.ts
+++ b/tensorbored/webapp/reloader/reloader_component_test.ts
@@ -72,7 +72,7 @@ describe('reloader_component', () => {
     }).compileComponents();
     store = TestBed.inject<Store>(Store) as MockStore;
     fakeDocument = TestBed.inject(DOCUMENT);
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   it('dispatches reload action every reload period', fakeAsync(() => {

--- a/tensorbored/webapp/runs/effects/runs_effects.ts
+++ b/tensorbored/webapp/runs/effects/runs_effects.ts
@@ -840,7 +840,7 @@ export class RunsEffects {
       take(1),
       mergeMap((loadState) => {
         if (loadState.state === DataLoadState.FAILED) {
-          return throwError(new Error('Pending request failed'));
+          return throwError(() => new Error('Pending request failed'));
         }
         return of(loadState);
       }),

--- a/tensorbored/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorbored/webapp/runs/views/runs_table/runs_table_test.ts
@@ -126,7 +126,7 @@ describe('runs_table', () => {
       tolkien: {aliasText: 'The Lord of the Rings', aliasNumber: 2},
     });
     store.overrideSelector(getActiveRoute, buildExperimentRouteFromId('123'));
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
   });
 
   describe('runs data table integration', () => {

--- a/tensorbored/webapp/settings/_views/settings_test.ts
+++ b/tensorbored/webapp/settings/_views/settings_test.ts
@@ -74,7 +74,7 @@ describe('settings test', () => {
       ],
     }).compileComponents();
     store = TestBed.inject<Store>(Store) as MockStore;
-    dispatchSpy = spyOn(store, 'dispatch');
+    dispatchSpy = spyOn(store, 'dispatch') as jasmine.Spy;
     overlayContainer = TestBed.inject(OverlayContainer);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation for features / changes

Sync with upstream `tensorflow/tensorboard` master which had 3 new commits since our last sync. These are all housekeeping/refactoring changes with no behavioral impact. We also extend the intent of each upstream change to TensorBored-specific code that upstream didn't touch.

## Technical description of changes

### Upstream merge (3 commits)

1. **`e6df954`** — Add explicit `changeDetection` property on all Angular components. Every `@Component` decorator now explicitly declares `ChangeDetectionStrategy.Default` or `.OnPush` instead of relying on the implicit default. ~50 upstream component files affected.

2. **`8e7bbc6`** — Remove usages of the `Component` interface. Replaces `Type<Component>` with `Type<unknown>` in routing, plugin registry, and customization code. The `Component` interface had only optional properties and provided no real type safety.

3. **`81e6137`** — Fix TypeScript linter errors. Casts `spyOn(store, 'dispatch')` to `jasmine.Spy` across 18 test files for NgRx dispatch overload compatibility. Updates `throwError` to factory form per RxJS 7. Adds tslint suppressions for snake_case API keys.

### Merge conflict resolution

One conflict in `scalar_card_test.ts` — upstream reorganized imports alphabetically; our code had TensorBored-specific imports (`metricsTagYAxisScaleChanged`, `metricsTagXAxisScaleChanged`). Resolved by merging both sets in alphabetical order.

### Extending upstream intent to TensorBored code

**Explicit changeDetection** (from commit 1):
- Added `changeDetection: ChangeDetectionStrategy.Default` to `BuildBadgeComponent` — the only TensorBored-specific component missing it. All other TensorBored components (profile menu, superimposed cards, etc.) already had explicit `OnPush`.

**Remove Component interface** (from commit 2):
- No action needed — TensorBored code already uses `Type<unknown>` everywhere. No `Type<Component>` usages existed.

**Linter fixes** (from commit 3):
- Cast `spyOn(store, 'dispatch')` to `jasmine.Spy` in 17 additional test files that upstream didn't touch (webapp: 10 files, debugger plugin: 7 files).
- Updated `throwError(new Error(...))` to factory form `throwError(() => new Error(...))` in `runs_effects.ts`.

## Screenshots of UI changes (or N/A)

N/A — No UI changes. All modifications are refactoring/linting.

## Detailed steps to verify changes work correctly (as executed by you)

1. Verified merge produces only 1 conflict (scalar_card_test.ts), resolved correctly
2. Searched entire codebase for remaining `spyOn(store, 'dispatch')` without `jasmine.Spy` cast — none found
3. Searched entire codebase for remaining `throwError(new Error(` non-factory form — none found
4. Searched for TensorBored components missing explicit `changeDetection` — only `build_badge_component.ts` found and fixed
5. Searched for remaining `Type<Component>` usages — none found

## Alternate designs / implementations considered (or N/A)

N/A — Straightforward upstream sync with mechanical extension of the same patterns to our code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4133be-eaab-4888-958b-727e3d103d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4133be-eaab-4888-958b-727e3d103d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

