### PR TITLE
Make superimposed section collapsible like other tag group sections

### DIFF
--- a/tensorbored/webapp/metrics/actions/index.ts
+++ b/tensorbored/webapp/metrics/actions/index.ts
@@ -206,6 +206,10 @@ export const metricsTagGroupExpansionStateLoaded = createAction(
   props<{expandedGroups: Array<[string, boolean]>}>()
 );
 
+export const metricsSuperimposedSectionExpansionChanged = createAction(
+  '[Metrics] Superimposed Section Expansion Changed'
+);
+
 export const cardFullWidthStateLoaded = createAction(
   '[Metrics] Card Full Width State Loaded From Storage',
   props<{fullWidthCardIds: string[]; fullWidthSuperimposedCardIds: string[]}>()

--- a/tensorbored/webapp/metrics/effects/index.ts
+++ b/tensorbored/webapp/metrics/effects/index.ts
@@ -108,6 +108,7 @@ import {
   getTagSymlogLinearThresholds,
   getSuperimposedCardsWithMetadata,
   getMetricsTagGroupExpansionMap,
+  getMetricsSuperimposedSectionExpanded,
   getCardStateMap,
   getFullWidthSuperimposedCards,
 } from '../store';
@@ -875,22 +876,23 @@ export class MetricsEffects implements OnInitEffects {
     this.persistTagGroupExpansion$ = this.actions$.pipe(
       ofType(
         actions.metricsTagGroupExpansionChanged,
-        actions.metricsTagMetadataLoaded
+        actions.metricsTagMetadataLoaded,
+        actions.metricsSuperimposedSectionExpansionChanged
       ),
       debounceTime(200),
-      withLatestFrom(this.store.select(getMetricsTagGroupExpansionMap)),
-      tap(([, expansionMap]) => {
+      withLatestFrom(
+        this.store.select(getMetricsTagGroupExpansionMap),
+        this.store.select(getMetricsSuperimposedSectionExpanded)
+      ),
+      tap(([, expansionMap, superimposedExpanded]) => {
         const entries: Array<[string, boolean]> = Array.from(
           expansionMap.entries()
         );
-        if (entries.length > 0) {
-          window.localStorage.setItem(
-            TAG_GROUP_EXPANSION_STORAGE_KEY,
-            JSON.stringify({version: 1, groups: entries})
-          );
-        } else {
-          window.localStorage.removeItem(TAG_GROUP_EXPANSION_STORAGE_KEY);
-        }
+        entries.push(['__superimposed__', superimposedExpanded]);
+        window.localStorage.setItem(
+          TAG_GROUP_EXPANSION_STORAGE_KEY,
+          JSON.stringify({version: 1, groups: entries})
+        );
         window.dispatchEvent(new CustomEvent('tb-tag-group-expansion-changed'));
       })
     );

--- a/tensorbored/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorbored/webapp/metrics/store/metrics_reducers.ts
@@ -1292,7 +1292,10 @@ const reducer = createReducer(
     return {...state, tagGroupExpanded, superimposedSectionExpanded};
   }),
   on(actions.metricsSuperimposedSectionExpansionChanged, (state) => {
-    return {...state, superimposedSectionExpanded: !state.superimposedSectionExpanded};
+    return {
+      ...state,
+      superimposedSectionExpanded: !state.superimposedSectionExpanded,
+    };
   }),
   on(
     actions.cardFullWidthStateLoaded,

--- a/tensorbored/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorbored/webapp/metrics/store/metrics_reducers.ts
@@ -502,6 +502,7 @@ const {initialState, reducers: namespaceContextedReducer} =
       superimposedCardMetadataMap: {},
       superimposedCardList: [],
       fullWidthSuperimposedCards: new Set<string>(),
+      superimposedSectionExpanded: true,
     },
     {
       isSettingsPaneOpen: true,
@@ -1280,8 +1281,18 @@ const reducer = createReducer(
     return {...state, tagGroupExpanded};
   }),
   on(actions.metricsTagGroupExpansionStateLoaded, (state, {expandedGroups}) => {
-    const tagGroupExpanded = new Map<string, boolean>(expandedGroups);
-    return {...state, tagGroupExpanded};
+    const superimposedEntry = expandedGroups.find(
+      ([key]) => key === '__superimposed__'
+    );
+    const tagGroupExpanded = new Map<string, boolean>(
+      expandedGroups.filter(([key]) => key !== '__superimposed__')
+    );
+    const superimposedSectionExpanded =
+      superimposedEntry !== undefined ? superimposedEntry[1] : true;
+    return {...state, tagGroupExpanded, superimposedSectionExpanded};
+  }),
+  on(actions.metricsSuperimposedSectionExpansionChanged, (state) => {
+    return {...state, superimposedSectionExpanded: !state.superimposedSectionExpanded};
   }),
   on(
     actions.cardFullWidthStateLoaded,

--- a/tensorbored/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorbored/webapp/metrics/store/metrics_selectors.ts
@@ -473,6 +473,11 @@ export const getMetricsTagGroupExpansionMap = createSelector(
   }
 );
 
+export const getMetricsSuperimposedSectionExpanded = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => state.superimposedSectionExpanded
+);
+
 export const getMetricsLinkedTimeEnabled = createSelector(
   selectMetricsState,
   (state: MetricsState): boolean => {

--- a/tensorbored/webapp/metrics/store/metrics_types.ts
+++ b/tensorbored/webapp/metrics/store/metrics_types.ts
@@ -242,6 +242,13 @@ export interface MetricsNamespacedState {
    * Set of superimposed card IDs that are displayed at full width.
    */
   fullWidthSuperimposedCards: Set<SuperimposedCardId>;
+
+  /**
+   * Whether the Superimposed section header is expanded (cards visible).
+   * Defaults to true. Persisted in the same localStorage key as tagGroupExpanded,
+   * using the reserved key '__superimposed__'.
+   */
+  superimposedSectionExpanded: boolean;
 }
 
 export interface MetricsSettings {

--- a/tensorbored/webapp/metrics/testing.ts
+++ b/tensorbored/webapp/metrics/testing.ts
@@ -161,6 +161,7 @@ function buildBlankState(): MetricsState {
     superimposedCardMetadataMap: {},
     superimposedCardList: [],
     fullWidthSuperimposedCards: new Set<string>(),
+    superimposedSectionExpanded: true,
   };
 }
 

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
@@ -22,15 +22,20 @@ limitations under the License.
 .group-toolbar {
   @include tb-theme-background-prop(background-color, background);
   @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
+  @include tb-theme-foreground-prop(color, text);
   align-items: center;
   background-color: #fff;
+  border: 0;
+  cursor: pointer;
   display: flex;
   flex: none;
+  font: inherit;
   height: 42px;
   margin-bottom: -1px;
   padding: 0 16px;
   position: sticky;
   top: 0;
+  width: 100%;
   z-index: 1;
   box-shadow: 0px 2px 4px 0px rgba(#000, 15%);
   @include tb-dark-theme {
@@ -40,8 +45,10 @@ limitations under the License.
   .left-items {
     align-items: center;
     display: flex;
+    flex-grow: 1;
     gap: 10px;
     overflow: hidden;
+    text-align: left;
 
     mat-icon {
       color: #673ab7;
@@ -68,6 +75,10 @@ limitations under the License.
     font-size: 12px;
     white-space: nowrap;
   }
+}
+
+.expand-group-icon {
+  @include tb-theme-foreground-prop(color, secondary-text);
 }
 
 .superimposed-cards-grid {

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.scss
@@ -21,11 +21,11 @@ limitations under the License.
 
 .group-toolbar {
   @include tb-theme-background-prop(background-color, background);
-  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   @include tb-theme-foreground-prop(color, text);
   align-items: center;
   background-color: #fff;
   border: 0;
+  @include tb-theme-foreground-prop(border-bottom, border, 1px solid);
   cursor: pointer;
   display: flex;
   flex: none;

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
@@ -15,8 +15,10 @@ limitations under the License.
 import {
   ChangeDetectionStrategy,
   Component,
+  EventEmitter,
   Input,
   OnChanges,
+  Output,
   SimpleChanges,
 } from '@angular/core';
 import {Store} from '@ngrx/store';
@@ -35,7 +37,12 @@ const MAX_CARD_MIN_WIDTH_IN_PX = 735;
   selector: 'superimposed-cards-view-component',
   template: `
     <ng-container *ngIf="superimposedCards.length > 0">
-      <div class="group-toolbar">
+      <button
+        class="group-toolbar"
+        i18n-aria-label="A button that allows user to expand the superimposed section."
+        aria-label="Expand superimposed section"
+        (click)="expansionToggled.emit()"
+      >
         <div class="left-items">
           <mat-icon svgIcon="group_work_24px"></mat-icon>
           <span class="group-text">
@@ -47,8 +54,18 @@ const MAX_CARD_MIN_WIDTH_IN_PX = 735;
             >
           </span>
         </div>
-      </div>
+        <span class="expand-group-icon">
+          <mat-icon
+            *ngIf="isExpanded; else expandMore"
+            svgIcon="expand_less_24px"
+          ></mat-icon>
+          <ng-template #expandMore>
+            <mat-icon svgIcon="expand_more_24px"></mat-icon>
+          </ng-template>
+        </span>
+      </button>
       <div
+        *ngIf="isExpanded"
         class="superimposed-cards-grid"
         [style.grid-template-columns]="gridTemplateColumn"
       >
@@ -76,6 +93,8 @@ export class SuperimposedCardsViewComponent implements OnChanges {
   @Input() cardObserver!: CardObserver;
   @Input() superimposedCards: SuperimposedCardMetadata[] = [];
   @Input() cardMinWidth: number | null = null;
+  @Input() isExpanded: boolean = true;
+  @Output() expansionToggled = new EventEmitter<void>();
 
   gridTemplateColumn = '';
 

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_component.ts
@@ -39,7 +39,9 @@ const MAX_CARD_MIN_WIDTH_IN_PX = 735;
     <ng-container *ngIf="superimposedCards.length > 0">
       <button
         class="group-toolbar"
-        i18n-aria-label="A button that allows user to expand the superimposed section."
+        i18n-aria-label="
+          A button that allows user to expand the superimposed section.
+        "
         aria-label="Expand superimposed section"
         (click)="expansionToggled.emit()"
       >

--- a/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_container.ts
+++ b/tensorbored/webapp/metrics/views/main_view/superimposed_cards_view_container.ts
@@ -18,7 +18,11 @@ import {Observable} from 'rxjs';
 import {startWith} from 'rxjs/operators';
 import {State} from '../../../app_state';
 import {getMetricsCardMinWidth} from '../../../selectors';
-import {getSuperimposedCardsWithMetadata} from '../../store';
+import {
+  getSuperimposedCardsWithMetadata,
+  getMetricsSuperimposedSectionExpanded,
+} from '../../store';
+import {metricsSuperimposedSectionExpansionChanged} from '../../actions';
 import {SuperimposedCardMetadata} from '../../types';
 import {CardObserver} from '../card_renderer/card_lazy_loader';
 
@@ -30,6 +34,8 @@ import {CardObserver} from '../card_renderer/card_lazy_loader';
       [superimposedCards]="superimposedCards$ | async"
       [cardObserver]="cardObserver"
       [cardMinWidth]="cardMinWidth$ | async"
+      [isExpanded]="isExpanded$ | async"
+      (expansionToggled)="onExpansionToggled()"
     ></superimposed-cards-view-component>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -39,11 +45,17 @@ export class SuperimposedCardsViewContainer {
 
   readonly superimposedCards$: Observable<SuperimposedCardMetadata[]>;
   readonly cardMinWidth$: Observable<number | null>;
+  readonly isExpanded$: Observable<boolean>;
 
   constructor(private readonly store: Store<State>) {
     this.superimposedCards$ = this.store
       .select(getSuperimposedCardsWithMetadata)
       .pipe(startWith([]));
     this.cardMinWidth$ = this.store.select(getMetricsCardMinWidth);
+    this.isExpanded$ = this.store.select(getMetricsSuperimposedSectionExpanded);
+  }
+
+  onExpansionToggled() {
+    this.store.dispatch(metricsSuperimposedSectionExpansionChanged());
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Superimposed section header on the time series tab was a non-interactive `div`, while every other section (Pinned, and all tag groups) has a clickable toolbar that collapses/expands the cards. This PR brings the Superimposed section up to the same standard.

## Changes

### State / store
- Added `superimposedSectionExpanded: boolean` (default `true`) to `MetricsNamespacedState`
- Added `metricsSuperimposedSectionExpansionChanged` action (no props — it's a pure toggle)
- Added reducer case that flips `superimposedSectionExpanded`
- Added `getMetricsSuperimposedSectionExpanded` selector
- Updated `buildBlankState()` in `testing.ts` to include the new field

### Persistence
Reuses the existing `_tb_tag_group_expansion.v1` localStorage key. The superimposed section's state is stored as a `['__superimposed__', boolean]` entry alongside the tag group entries. On load, the reducer filters out that reserved key before populating `tagGroupExpanded`, and reads it separately to set `superimposedSectionExpanded`. The `persistTagGroupExpansion$` effect now triggers on `metricsSuperimposedSectionExpansionChanged` as well.

### UI
- Converted the `div.group-toolbar` in `SuperimposedCardsViewComponent` to a `<button>` that emits `expansionToggled`
- Added `expand_less_24px` / `expand_more_24px` icon in a `span.expand-group-icon` (same pattern as `CardGroupToolBarComponent`)
- The cards grid is wrapped in `*ngIf="isExpanded"`
- SCSS updated to style the button correctly: `border: 0`, `cursor: pointer`, `font: inherit`, `width: 100%`, matching the existing card group toolbar style
- `SuperimposedCardsViewContainer` wires `isExpanded$` from the store and dispatches the action on toggle

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8294bd3-5f78-4fe8-9a52-8dddd73a9d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8294bd3-5f78-4fe8-9a52-8dddd73a9d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

